### PR TITLE
Feat: 매거진 관리 : 삭제 기능

### DIFF
--- a/src/application/store/magazine/hook.ts
+++ b/src/application/store/magazine/hook.ts
@@ -1,8 +1,14 @@
 import { useRecoilState, useRecoilValue, useResetRecoilState, useSetRecoilState } from 'recoil';
 
-import { magazineInfoSelector, magazineState, pageSelector } from '@/application/store/magazine/state';
+import {
+  deleteMagazineList,
+  magazineInfoSelector,
+  magazineState,
+  pageSelector,
+} from '@/application/store/magazine/state';
 
 export const useSetMagazineInfo = () => useSetRecoilState(magazineInfoSelector);
 export const usePage = (id: number) => useRecoilState(pageSelector(id));
 export const useMagazineInfo = () => useRecoilValue(magazineState);
 export const useResetMagazineInfo = () => useResetRecoilState(magazineState);
+export const useMagazineDeleteList = () => useRecoilValue(deleteMagazineList);

--- a/src/application/store/magazine/state.ts
+++ b/src/application/store/magazine/state.ts
@@ -56,7 +56,7 @@ export const magazineInfoSelector = selector<Partial<MagazineState>>({
     !(newValue instanceof DefaultValue) && set(magazineState, (prevValue) => ({ ...prevValue, ...newValue })),
 });
 
-export const deleteOption = atom({
+export const multiDelete = atom({
   key: 'deleteOption',
   default: false,
 });

--- a/src/application/store/magazine/state.ts
+++ b/src/application/store/magazine/state.ts
@@ -71,14 +71,3 @@ export const deleteMagazineList = selector({
   get: ({ get }) => get(magazineIdsArray),
   set: ({ set }, newValue) => set(magazineIdsArray, (prevValue) => ({ ...prevValue, ...newValue })),
 });
-
-// 다중선택 -> 취소 클릭 시 ids 배열 초기화
-// export const initMagazineArray = selector({
-//   key: 'initMagazineArray',
-//   get: ({ get }) => {
-//     const isOption = get(deleteOption);
-//     if (isOption === false) {
-//       return [];
-//     }
-//   },
-// });

--- a/src/application/store/magazine/state.ts
+++ b/src/application/store/magazine/state.ts
@@ -66,6 +66,12 @@ export const magazineIdsArray = atom<Array<number>>({
   default: [],
 });
 
+export const deleteMagazineList = selector({
+  key: 'deleteMagazineList',
+  get: ({ get }) => get(magazineIdsArray),
+  set: ({ set }, newValue) => set(magazineIdsArray, (prevValue) => ({ ...prevValue, ...newValue })),
+});
+
 // 다중선택 -> 취소 클릭 시 ids 배열 초기화
 // export const initMagazineArray = selector({
 //   key: 'initMagazineArray',

--- a/src/application/store/magazine/state.ts
+++ b/src/application/store/magazine/state.ts
@@ -55,3 +55,24 @@ export const magazineInfoSelector = selector<Partial<MagazineState>>({
   set: ({ set }, newValue) =>
     !(newValue instanceof DefaultValue) && set(magazineState, (prevValue) => ({ ...prevValue, ...newValue })),
 });
+
+export const deleteOption = atom({
+  key: 'deleteOption',
+  default: false,
+});
+
+export const magazineIdsArray = atom<Array<number>>({
+  key: 'magazineIdsArray',
+  default: [],
+});
+
+// 다중선택 -> 취소 클릭 시 ids 배열 초기화
+// export const initMagazineArray = selector({
+//   key: 'initMagazineArray',
+//   get: ({ get }) => {
+//     const isOption = get(deleteOption);
+//     if (isOption === false) {
+//       return [];
+//     }
+//   },
+// });

--- a/src/components/magazine/MagazineList/TabMagazine.tsx
+++ b/src/components/magazine/MagazineList/TabMagazine.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import Link from 'next/link';
-import { useCallback } from 'react';
+import { useCallback, useRef } from 'react';
 import { useRecoilState } from 'recoil';
 
 import type { UseScrollDetectOption } from '@/application/hooks/utils/useScrollDetect';
@@ -22,17 +22,15 @@ const TabMagazine = ({ magazines, selectItem, selectDeleteOption, onScrollDown }
   const multiSelectOn = selectDeleteOption;
 
   // 썸네일 클릭 시 해당 id 추가, 선택 취소 시 id 확인 후 제거
-  const [magazineItems, setMagazineItems] = useRecoilState(magazineIdsArray);
+  const [, setMagazineItems] = useRecoilState(magazineIdsArray);
+  const pickSet = useRef(new Set<number>());
 
   const selectMagazineItems = useCallback(
     (id: number) => {
-      magazineItems.includes(id)
-        ? setMagazineItems(magazineItems.filter((el) => el !== id))
-        : setMagazineItems((prev) => [...prev, id]);
+      pickSet.current.has(id) ? pickSet.current.delete(id) : pickSet.current.add(id);
+      setMagazineItems(Array.from(pickSet.current));
     },
-    // TODO 해당 경고 고민해보고 수정하기
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [magazineItems],
+    [pickSet, setMagazineItems],
   );
 
   return (

--- a/src/components/magazine/MagazineList/TabMagazine.tsx
+++ b/src/components/magazine/MagazineList/TabMagazine.tsx
@@ -1,5 +1,6 @@
 import { css } from '@emotion/react';
 import Link from 'next/link';
+import { useCallback, useRef, useState } from 'react';
 
 import type { UseScrollDetectOption } from '@/application/hooks/utils/useScrollDetect';
 import useScrollDetect from '@/application/hooks/utils/useScrollDetect';
@@ -17,6 +18,23 @@ interface TabMagazineProps {
 const TabMagazine = ({ magazines, selectItem, deleteOption, onScrollDown }: TabMagazineProps) => {
   const ref = useScrollDetect<HTMLDivElement>({ onScroll: onScrollDown });
   const boolOption = deleteOption;
+
+  // TODO 테스트 후 recoil로 수정 => 취소 눌렀을 때 빈 배열이 될 수 있도록 만들어야 함 (현재는 취소후에도 그대로 id값이 남아있음)
+  // 썸네일 클릭 시 각 썸네일 별 true일 때만 ids 담기, false일 시 filter를 이용해 다시 제외
+  // selected 조건문 제대로 동작안함. 수정하기
+  const [magazineItems, setMagazineItems] = useState<Array<number>>([]);
+  const magazineRef = useRef<HTMLDivElement | null>(null);
+  const selectMagazineItems = useCallback(
+    (selected: boolean, id: number) => {
+      selected ? setMagazineItems((prev) => [...prev, id]) : setMagazineItems(magazineItems.filter((el) => el !== id));
+    },
+    [magazineItems],
+  );
+
+  const test = [...magazines];
+
+  console.log(magazineItems);
+  console.log(test);
 
   return (
     <div
@@ -60,12 +78,15 @@ const TabMagazine = ({ magazines, selectItem, deleteOption, onScrollDown }: TabM
             >
               {boolOption ? (
                 <div>
-                  {' '}
                   <Photo
+                    ref={magazineRef}
                     blur={<PhotoSelect enabled={selectItem} />}
                     src={magazine.cover_url}
                     width={'196px'}
                     height={'255px'}
+                    onClick={() => {
+                      // selectMagazineItems(ref, magazine.magazine_id);
+                    }}
                   />
                 </div>
               ) : (

--- a/src/components/magazine/MagazineList/TabMagazine.tsx
+++ b/src/components/magazine/MagazineList/TabMagazine.tsx
@@ -13,13 +13,13 @@ import NoMagazine from '@/components/magazine/NoMagazine';
 interface TabMagazineProps {
   magazines: MagazineThumbnail[];
   selectItem?: boolean;
-  option?: boolean;
+  selectDeleteOption?: boolean;
   onScrollDown?: UseScrollDetectOption['onScroll'];
 }
 
-const TabMagazine = ({ magazines, selectItem, option, onScrollDown }: TabMagazineProps) => {
+const TabMagazine = ({ magazines, selectItem, selectDeleteOption, onScrollDown }: TabMagazineProps) => {
   const ref = useScrollDetect<HTMLDivElement>({ onScroll: onScrollDown });
-  const boolOption = option;
+  const multiSelectOn = selectDeleteOption;
 
   // 썸네일 클릭 시 해당 id 추가, 선택 취소 시 id 확인 후 제거
   const [magazineItems, setMagazineItems] = useRecoilState(magazineIdsArray);
@@ -75,7 +75,7 @@ const TabMagazine = ({ magazines, selectItem, option, onScrollDown }: TabMagazin
                 `
               }
             >
-              {boolOption ? (
+              {multiSelectOn ? (
                 <div>
                   <Photo
                     blur={<PhotoSelect enabled={selectItem} />}

--- a/src/components/magazine/MagazineList/TabMagazine.tsx
+++ b/src/components/magazine/MagazineList/TabMagazine.tsx
@@ -21,19 +21,19 @@ const TabMagazine = ({ magazines, selectItem, option, onScrollDown }: TabMagazin
   const ref = useScrollDetect<HTMLDivElement>({ onScroll: onScrollDown });
   const boolOption = option;
 
-  // 썸네일 클릭 시 각 썸네일 별 true일 때만 ids 담기, false일 시 filter를 이용해 다시 제외
-  // selected 조건문 제대로 동작안함. 수정하기
+  // 썸네일 클릭 시 해당 id 추가, 선택 취소 시 id 확인 후 제거
   const [magazineItems, setMagazineItems] = useRecoilState(magazineIdsArray);
-  // const magazineRef = useRef<HTMLDivElement | null>(null);
 
   const selectMagazineItems = useCallback(
-    (selected: any, id: number) => {
-      selected ? setMagazineItems((prev) => [...prev, id]) : setMagazineItems(magazineItems.filter((el) => el !== id));
+    (id: number) => {
+      magazineItems.includes(id)
+        ? setMagazineItems(magazineItems.filter((el) => el !== id))
+        : setMagazineItems((prev) => [...prev, id]);
     },
+    // TODO 해당 경고 고민해보고 수정하기
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     [magazineItems],
   );
-
-  console.log(magazineItems);
 
   return (
     <div
@@ -82,7 +82,7 @@ const TabMagazine = ({ magazines, selectItem, option, onScrollDown }: TabMagazin
                     src={magazine.cover_url}
                     width={'196px'}
                     height={'255px'}
-                    onClick={() => selectMagazineItems(ref, magazine.magazine_id)}
+                    onClick={() => selectMagazineItems(magazine.magazine_id)}
                   />
                 </div>
               ) : (

--- a/src/components/magazine/MagazineList/TabMagazine.tsx
+++ b/src/components/magazine/MagazineList/TabMagazine.tsx
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import Link from 'next/link';
 import { useCallback, useRef } from 'react';
-import { useRecoilState } from 'recoil';
+import { useSetRecoilState } from 'recoil';
 
 import type { UseScrollDetectOption } from '@/application/hooks/utils/useScrollDetect';
 import useScrollDetect from '@/application/hooks/utils/useScrollDetect';
@@ -13,16 +13,16 @@ import NoMagazine from '@/components/magazine/NoMagazine';
 interface TabMagazineProps {
   magazines: MagazineThumbnail[];
   selectItem?: boolean;
-  selectDeleteOption?: boolean;
+  selectDeleteBtn?: boolean;
   onScrollDown?: UseScrollDetectOption['onScroll'];
 }
 
-const TabMagazine = ({ magazines, selectItem, selectDeleteOption, onScrollDown }: TabMagazineProps) => {
+const TabMagazine = ({ magazines, selectItem, selectDeleteBtn, onScrollDown }: TabMagazineProps) => {
   const ref = useScrollDetect<HTMLDivElement>({ onScroll: onScrollDown });
-  const multiSelectOn = selectDeleteOption;
+  const multiSelectOn = selectDeleteBtn;
 
   // 썸네일 클릭 시 해당 id 추가, 선택 취소 시 id 확인 후 제거
-  const [, setMagazineItems] = useRecoilState(magazineIdsArray);
+  const setMagazineItems = useSetRecoilState(magazineIdsArray);
   const pickSet = useRef(new Set<number>());
 
   const selectMagazineItems = useCallback(

--- a/src/components/magazine/MagazineList/TabMagazine.tsx
+++ b/src/components/magazine/MagazineList/TabMagazine.tsx
@@ -10,11 +10,13 @@ import NoMagazine from '@/components/magazine/NoMagazine';
 interface TabMagazineProps {
   magazines: MagazineThumbnail[];
   selectItem?: boolean;
+  deleteOption?: boolean;
   onScrollDown?: UseScrollDetectOption['onScroll'];
 }
 
-const TabMagazine = ({ magazines, selectItem, onScrollDown }: TabMagazineProps) => {
+const TabMagazine = ({ magazines, selectItem, deleteOption, onScrollDown }: TabMagazineProps) => {
   const ref = useScrollDetect<HTMLDivElement>({ onScroll: onScrollDown });
+  const boolOption = deleteOption;
 
   return (
     <div
@@ -56,14 +58,26 @@ const TabMagazine = ({ magazines, selectItem, onScrollDown }: TabMagazineProps) 
                 `
               }
             >
-              <Link href={`/magazine/${magazine.magazine_id}`}>
-                <Photo
-                  blur={<PhotoSelect enabled={selectItem} />}
-                  src={magazine.cover_url}
-                  width={'196px'}
-                  height={'255px'}
-                />
-              </Link>
+              {boolOption ? (
+                <div>
+                  {' '}
+                  <Photo
+                    blur={<PhotoSelect enabled={selectItem} />}
+                    src={magazine.cover_url}
+                    width={'196px'}
+                    height={'255px'}
+                  />
+                </div>
+              ) : (
+                <Link href={`/magazine/${magazine.magazine_id}`}>
+                  <Photo
+                    blur={<PhotoSelect enabled={selectItem} />}
+                    src={magazine.cover_url}
+                    width={'196px'}
+                    height={'255px'}
+                  />
+                </Link>
+              )}
               <span
                 css={(theme) =>
                   css`

--- a/src/components/magazine/MagazineList/TabMagazine.tsx
+++ b/src/components/magazine/MagazineList/TabMagazine.tsx
@@ -1,9 +1,11 @@
 import { css } from '@emotion/react';
 import Link from 'next/link';
-import { useCallback, useRef, useState } from 'react';
+import { useCallback } from 'react';
+import { useRecoilState } from 'recoil';
 
 import type { UseScrollDetectOption } from '@/application/hooks/utils/useScrollDetect';
 import useScrollDetect from '@/application/hooks/utils/useScrollDetect';
+import { magazineIdsArray } from '@/application/store/magazine/state';
 import Photo from '@/components/common/Photo';
 import PhotoSelect from '@/components/common/Photo/PhotoSelect';
 import NoMagazine from '@/components/magazine/NoMagazine';
@@ -11,30 +13,27 @@ import NoMagazine from '@/components/magazine/NoMagazine';
 interface TabMagazineProps {
   magazines: MagazineThumbnail[];
   selectItem?: boolean;
-  deleteOption?: boolean;
+  option?: boolean;
   onScrollDown?: UseScrollDetectOption['onScroll'];
 }
 
-const TabMagazine = ({ magazines, selectItem, deleteOption, onScrollDown }: TabMagazineProps) => {
+const TabMagazine = ({ magazines, selectItem, option, onScrollDown }: TabMagazineProps) => {
   const ref = useScrollDetect<HTMLDivElement>({ onScroll: onScrollDown });
-  const boolOption = deleteOption;
+  const boolOption = option;
 
-  // TODO 테스트 후 recoil로 수정 => 취소 눌렀을 때 빈 배열이 될 수 있도록 만들어야 함 (현재는 취소후에도 그대로 id값이 남아있음)
   // 썸네일 클릭 시 각 썸네일 별 true일 때만 ids 담기, false일 시 filter를 이용해 다시 제외
   // selected 조건문 제대로 동작안함. 수정하기
-  const [magazineItems, setMagazineItems] = useState<Array<number>>([]);
-  const magazineRef = useRef<HTMLDivElement | null>(null);
+  const [magazineItems, setMagazineItems] = useRecoilState(magazineIdsArray);
+  // const magazineRef = useRef<HTMLDivElement | null>(null);
+
   const selectMagazineItems = useCallback(
-    (selected: boolean, id: number) => {
+    (selected: any, id: number) => {
       selected ? setMagazineItems((prev) => [...prev, id]) : setMagazineItems(magazineItems.filter((el) => el !== id));
     },
     [magazineItems],
   );
 
-  const test = [...magazines];
-
   console.log(magazineItems);
-  console.log(test);
 
   return (
     <div
@@ -79,14 +78,11 @@ const TabMagazine = ({ magazines, selectItem, deleteOption, onScrollDown }: TabM
               {boolOption ? (
                 <div>
                   <Photo
-                    ref={magazineRef}
                     blur={<PhotoSelect enabled={selectItem} />}
                     src={magazine.cover_url}
                     width={'196px'}
                     height={'255px'}
-                    onClick={() => {
-                      // selectMagazineItems(ref, magazine.magazine_id);
-                    }}
+                    onClick={() => selectMagazineItems(ref, magazine.magazine_id)}
                   />
                 </div>
               ) : (

--- a/src/containers/magazine/TabMagazineViewContainer.tsx
+++ b/src/containers/magazine/TabMagazineViewContainer.tsx
@@ -1,11 +1,13 @@
 import { css } from '@emotion/react';
 import Image from 'next/image';
 import React, { useRef, useState } from 'react';
+import { useRecoilState } from 'recoil';
 
 import { useGetMagazines } from '@/application/hooks/api/magazine';
 import usePopup from '@/application/hooks/common/usePopup';
 import useToast from '@/application/hooks/common/useToast';
 import type { UseScrollDetectOption } from '@/application/hooks/utils/useScrollDetect';
+import { deleteOption, magazineIdsArray } from '@/application/store/magazine/state';
 import { DeletePopup } from '@/components/common/Popup/Sentence';
 import Tab from '@/components/common/Tab';
 import { TabMagazine } from '@/components/magazine/MagazineList';
@@ -27,7 +29,8 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
   const { magazines } = useGetMagazines();
 
   const [selected, setSelected] = useState(initSelectedContext);
-  const [deleteOption, isDeleteOption] = useState(false);
+  const [option, isOption] = useRecoilState(deleteOption);
+  const [, setMagazineItems] = useRecoilState(magazineIdsArray);
   const ref = useRef<SelectContext>('myMagazine');
   const setNavigation = useBottomNavigationContext()[1];
   const { show } = useToast();
@@ -42,7 +45,7 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
   const showDeleteMagazineToast = () => show({ content: <DeleteScrapToast onDelete={handleDeleteMagazine} /> });
 
   const handleMultiSelect = () => {
-    isDeleteOption(!deleteOption);
+    isOption(!option);
     setSelected((prev) => {
       const ret = { ...prev };
       const deleted = ret[ref.current];
@@ -67,7 +70,7 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
             `}
           >
             {selected[ref.current] ? (
-              '취소'
+              <p onClick={() => setMagazineItems([])}>취소</p>
             ) : (
               <Image src={'/icon/multiSelect.svg'} width={18} height={18} alt="삭제아이콘" />
             )}
@@ -83,16 +86,11 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
             magazines={magazines}
             onScrollDown={onScrollDown}
             selectItem={selected.myMagazine}
-            deleteOption={deleteOption}
+            option={option}
           />
         </Tab.Content>
         <Tab.Content>
-          <TabMagazine
-            magazines={[]}
-            onScrollDown={onScrollDown}
-            selectItem={selected.saveMagazine}
-            deleteOption={deleteOption}
-          />
+          <TabMagazine magazines={[]} onScrollDown={onScrollDown} selectItem={selected.saveMagazine} option={option} />
         </Tab.Content>
       </Tab.Panel>
     </Tab>

--- a/src/containers/magazine/TabMagazineViewContainer.tsx
+++ b/src/containers/magazine/TabMagazineViewContainer.tsx
@@ -32,7 +32,7 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
   const [selected, setSelected] = useState(initSelectedContext);
   const [option, isOption] = useRecoilState(deleteOption);
   const [, setMagazineItems] = useRecoilState(magazineIdsArray);
-  const magazineItems = useMagazineDeleteList();
+  const magazineDeleteList = useMagazineDeleteList();
   const ref = useRef<SelectContext>('myMagazine');
   const setNavigation = useBottomNavigationContext()[1];
   const { show } = useToast();
@@ -40,9 +40,9 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
 
   const handleDeleteMagazine = () => {
     handleDeleteIds();
+    resetMagazineStates();
     setSelected({ ...selected, [ref.current]: false });
     popup(DeletePopup, 'success');
-    setNavigation('default');
   };
 
   const showDeleteMagazineToast = () => show({ content: <DeleteScrapToast onDelete={handleDeleteMagazine} /> });
@@ -61,17 +61,13 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
   // 매거진 삭제
   const mutation = useDeleteMagazines();
   const handleDeleteIds = () => {
-    console.log('매거진 아이템 확인해보기', magazineItems);
-    mutation.mutate(
-      { ids: magazineItems },
-      {
-        onSuccess: () => {
-          setMagazineItems([]);
-          console.log('삭제 성공!');
-        },
-      },
-    );
+    mutation.mutate({ ids: magazineDeleteList });
+  };
+
+  const resetMagazineStates = () => {
+    isOption(false);
     setMagazineItems([]);
+    setNavigation('default');
   };
 
   return (

--- a/src/containers/magazine/TabMagazineViewContainer.tsx
+++ b/src/containers/magazine/TabMagazineViewContainer.tsx
@@ -38,15 +38,11 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
   const { show } = useToast();
   const popup = usePopup();
 
-  console.log(magazineItems);
-
-  // TODO 멀티삭제 삭제 토스트 뜬 후에도 네비게이션 바 그대로인 버그 수정해야함(스크랩, 매거진)
-  // DeleteNavigation onClick에 바로 적용될 수 있도록 해당 함수에 delete mutate?
   const handleDeleteMagazine = () => {
-    console.log(magazineItems);
     handleDeleteIds();
     setSelected({ ...selected, [ref.current]: false });
     popup(DeletePopup, 'success');
+    setNavigation('default');
   };
 
   const showDeleteMagazineToast = () => show({ content: <DeleteScrapToast onDelete={handleDeleteMagazine} /> });
@@ -65,10 +61,17 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
   // 매거진 삭제
   const mutation = useDeleteMagazines();
   const handleDeleteIds = () => {
-    mutation.mutate(magazineItems, {
-      onSuccess: setMagazineItems([]),
-    });
-    console.log('삭제 성공!');
+    console.log('매거진 아이템 확인해보기', magazineItems);
+    mutation.mutate(
+      { ids: magazineItems },
+      {
+        onSuccess: () => {
+          setMagazineItems([]);
+          console.log('삭제 성공!');
+        },
+      },
+    );
+    setMagazineItems([]);
   };
 
   return (

--- a/src/containers/magazine/TabMagazineViewContainer.tsx
+++ b/src/containers/magazine/TabMagazineViewContainer.tsx
@@ -3,10 +3,11 @@ import Image from 'next/image';
 import React, { useRef, useState } from 'react';
 import { useRecoilState } from 'recoil';
 
-import { useGetMagazines } from '@/application/hooks/api/magazine';
+import { useDeleteMagazines, useGetMagazines } from '@/application/hooks/api/magazine';
 import usePopup from '@/application/hooks/common/usePopup';
 import useToast from '@/application/hooks/common/useToast';
 import type { UseScrollDetectOption } from '@/application/hooks/utils/useScrollDetect';
+import { useMagazineDeleteList } from '@/application/store/magazine/hook';
 import { deleteOption, magazineIdsArray } from '@/application/store/magazine/state';
 import { DeletePopup } from '@/components/common/Popup/Sentence';
 import Tab from '@/components/common/Tab';
@@ -31,13 +32,19 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
   const [selected, setSelected] = useState(initSelectedContext);
   const [option, isOption] = useRecoilState(deleteOption);
   const [, setMagazineItems] = useRecoilState(magazineIdsArray);
+  const magazineItems = useMagazineDeleteList();
   const ref = useRef<SelectContext>('myMagazine');
   const setNavigation = useBottomNavigationContext()[1];
   const { show } = useToast();
   const popup = usePopup();
 
+  console.log(magazineItems);
+
   // TODO 멀티삭제 삭제 토스트 뜬 후에도 네비게이션 바 그대로인 버그 수정해야함(스크랩, 매거진)
+  // DeleteNavigation onClick에 바로 적용될 수 있도록 해당 함수에 delete mutate?
   const handleDeleteMagazine = () => {
+    console.log(magazineItems);
+    handleDeleteIds();
     setSelected({ ...selected, [ref.current]: false });
     popup(DeletePopup, 'success');
   };
@@ -53,6 +60,15 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
       ret[ref.current] = !ret[ref.current];
       return ret;
     });
+  };
+
+  // 매거진 삭제
+  const mutation = useDeleteMagazines();
+  const handleDeleteIds = () => {
+    mutation.mutate(magazineItems, {
+      onSuccess: setMagazineItems([]),
+    });
+    console.log('삭제 성공!');
   };
 
   return (

--- a/src/containers/magazine/TabMagazineViewContainer.tsx
+++ b/src/containers/magazine/TabMagazineViewContainer.tsx
@@ -66,7 +66,11 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
               font-size: 15px;
             `}
           >
-            {selected[ref.current] ? '취소' : <Image src={'/icon/multiSelect.svg'} width={18} height={18} />}
+            {selected[ref.current] ? (
+              '취소'
+            ) : (
+              <Image src={'/icon/multiSelect.svg'} width={18} height={18} alt="삭제아이콘" />
+            )}
           </span>
         }
       >

--- a/src/containers/magazine/TabMagazineViewContainer.tsx
+++ b/src/containers/magazine/TabMagazineViewContainer.tsx
@@ -30,7 +30,7 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
   const { magazines } = useGetMagazines();
 
   const [selected, setSelected] = useState(initSelectedContext);
-  const [option, isOption] = useRecoilState(deleteOption);
+  const [selectDeleteOption, isSelectDeleteOption] = useRecoilState(deleteOption);
   const [deleteState, setDeleteState] = useState(false);
   const magazineDeleteList = useMagazineDeleteList();
   const resetDeleteItem = useResetRecoilState(magazineIdsArray);
@@ -48,7 +48,7 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
   const showDeleteMagazineToast = () => show({ content: <DeleteScrapToast onDelete={handleDeleteMagazine} /> });
 
   const handleMultiSelect = () => {
-    isOption(!option);
+    isSelectDeleteOption(!selectDeleteOption);
     setSelected((prev) => {
       const ret = { ...prev };
       const deleted = ret[ref.current];
@@ -70,7 +70,7 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
   };
 
   const resetMagazineStates = () => {
-    isOption(false);
+    isSelectDeleteOption(false);
     setNavigation('default');
     setDeleteState(!deleteState);
   };
@@ -113,11 +113,16 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
             magazines={magazines}
             onScrollDown={onScrollDown}
             selectItem={selected.myMagazine}
-            option={option}
+            selectDeleteOption={selectDeleteOption}
           />
         </Tab.Content>
         <Tab.Content>
-          <TabMagazine magazines={[]} onScrollDown={onScrollDown} selectItem={selected.saveMagazine} option={option} />
+          <TabMagazine
+            magazines={[]}
+            onScrollDown={onScrollDown}
+            selectItem={selected.saveMagazine}
+            selectDeleteOption={selectDeleteOption}
+          />
         </Tab.Content>
       </Tab.Panel>
     </Tab>

--- a/src/containers/magazine/TabMagazineViewContainer.tsx
+++ b/src/containers/magazine/TabMagazineViewContainer.tsx
@@ -8,7 +8,7 @@ import usePopup from '@/application/hooks/common/usePopup';
 import useToast from '@/application/hooks/common/useToast';
 import type { UseScrollDetectOption } from '@/application/hooks/utils/useScrollDetect';
 import { useMagazineDeleteList } from '@/application/store/magazine/hook';
-import { deleteOption, magazineIdsArray } from '@/application/store/magazine/state';
+import { magazineIdsArray, multiDelete } from '@/application/store/magazine/state';
 import { DeletePopup } from '@/components/common/Popup/Sentence';
 import Tab from '@/components/common/Tab';
 import { TabMagazine } from '@/components/magazine/MagazineList';
@@ -18,7 +18,6 @@ import { DeleteScrapToast } from '@/components/scrap/Toast';
 import { useBottomNavigationContext } from '../HOC/NavigationContext';
 
 interface MagazineTabProps {
-  deleteOption?: boolean;
   onScrollDown?: UseScrollDetectOption['onScroll'];
 }
 
@@ -30,7 +29,7 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
   const { magazines } = useGetMagazines();
 
   const [selected, setSelected] = useState(initSelectedContext);
-  const [selectDeleteOption, isSelectDeleteOption] = useRecoilState(deleteOption);
+  const [selectDeleteBtn, isSelectDeleteBtn] = useRecoilState(multiDelete);
   const [deleteState, setDeleteState] = useState(false);
   const magazineDeleteList = useMagazineDeleteList();
   const resetDeleteItem = useResetRecoilState(magazineIdsArray);
@@ -48,7 +47,7 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
   const showDeleteMagazineToast = () => show({ content: <DeleteScrapToast onDelete={handleDeleteMagazine} /> });
 
   const handleMultiSelect = () => {
-    isSelectDeleteOption(!selectDeleteOption);
+    isSelectDeleteBtn(!selectDeleteBtn);
     setSelected((prev) => {
       const ret = { ...prev };
       const deleted = ret[ref.current];
@@ -70,7 +69,7 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
   };
 
   const resetMagazineStates = () => {
-    isSelectDeleteOption(false);
+    isSelectDeleteBtn(false);
     setNavigation('default');
     setDeleteState(!deleteState);
   };
@@ -113,7 +112,7 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
             magazines={magazines}
             onScrollDown={onScrollDown}
             selectItem={selected.myMagazine}
-            selectDeleteOption={selectDeleteOption}
+            selectDeleteBtn={selectDeleteBtn}
           />
         </Tab.Content>
         <Tab.Content>
@@ -121,7 +120,7 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
             magazines={[]}
             onScrollDown={onScrollDown}
             selectItem={selected.saveMagazine}
-            selectDeleteOption={selectDeleteOption}
+            selectDeleteBtn={selectDeleteBtn}
           />
         </Tab.Content>
       </Tab.Panel>

--- a/src/containers/magazine/TabMagazineViewContainer.tsx
+++ b/src/containers/magazine/TabMagazineViewContainer.tsx
@@ -1,32 +1,72 @@
 import { css } from '@emotion/react';
 import Image from 'next/image';
-import React from 'react';
+import React, { useRef, useState } from 'react';
 
 import { useGetMagazines } from '@/application/hooks/api/magazine';
+import usePopup from '@/application/hooks/common/usePopup';
+import useToast from '@/application/hooks/common/useToast';
 import type { UseScrollDetectOption } from '@/application/hooks/utils/useScrollDetect';
+import { DeletePopup } from '@/components/common/Popup/Sentence';
 import Tab from '@/components/common/Tab';
 import { TabMagazine } from '@/components/magazine/MagazineList';
+import DeleteNavigation from '@/components/scrap/DeleteNavigation';
+import { DeleteScrapToast } from '@/components/scrap/Toast';
+
+import { useBottomNavigationContext } from '../HOC/NavigationContext';
 
 interface MagazineTabProps {
-  onMultiSelect?: () => void;
+  deleteOption?: boolean;
   onScrollDown?: UseScrollDetectOption['onScroll'];
 }
-const MyMagazineWithTab = ({ onMultiSelect, onScrollDown }: MagazineTabProps) => {
+
+// '내 매거진', '저장한 매거진'
+const initSelectedContext = { myMagazine: false, saveMagazine: false };
+type SelectContext = keyof typeof initSelectedContext;
+
+const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
   const { magazines } = useGetMagazines();
+
+  const [selected, setSelected] = useState(initSelectedContext);
+  const [deleteOption, isDeleteOption] = useState(false);
+  const ref = useRef<SelectContext>('myMagazine');
+  const setNavigation = useBottomNavigationContext()[1];
+  const { show } = useToast();
+  const popup = usePopup();
+
+  // TODO 멀티삭제 삭제 토스트 뜬 후에도 네비게이션 바 그대로인 버그 수정해야함(스크랩, 매거진)
+  const handleDeleteMagazine = () => {
+    setSelected({ ...selected, [ref.current]: false });
+    popup(DeletePopup, 'success');
+  };
+
+  const showDeleteMagazineToast = () => show({ content: <DeleteScrapToast onDelete={handleDeleteMagazine} /> });
+
+  const handleMultiSelect = () => {
+    isDeleteOption(!deleteOption);
+    setSelected((prev) => {
+      const ret = { ...prev };
+      const deleted = ret[ref.current];
+      deleted ? setNavigation('default') : setNavigation(<DeleteNavigation onClick={showDeleteMagazineToast} />);
+      ret[ref.current] = !ret[ref.current];
+      return ret;
+    });
+  };
+
   return (
     <Tab>
       <Tab.Group
         start
         decorator={
           <span
-            onClick={onMultiSelect}
+            onClick={handleMultiSelect}
             css={css`
               position: absolute;
               right: 0;
               bottom: 15px;
+              font-size: 15px;
             `}
           >
-            <Image src={'/icon/multiSelect.svg'} width={18} height={18} />
+            {selected[ref.current] ? '취소' : <Image src={'/icon/multiSelect.svg'} width={18} height={18} />}
           </span>
         }
       >
@@ -35,10 +75,20 @@ const MyMagazineWithTab = ({ onMultiSelect, onScrollDown }: MagazineTabProps) =>
       </Tab.Group>
       <Tab.Panel>
         <Tab.Content>
-          <TabMagazine magazines={magazines} onScrollDown={onScrollDown} />
+          <TabMagazine
+            magazines={magazines}
+            onScrollDown={onScrollDown}
+            selectItem={selected.myMagazine}
+            deleteOption={deleteOption}
+          />
         </Tab.Content>
         <Tab.Content>
-          <TabMagazine magazines={[]} onScrollDown={onScrollDown} />
+          <TabMagazine
+            magazines={[]}
+            onScrollDown={onScrollDown}
+            selectItem={selected.saveMagazine}
+            deleteOption={deleteOption}
+          />
         </Tab.Content>
       </Tab.Panel>
     </Tab>

--- a/src/containers/magazine/TabMagazineViewContainer.tsx
+++ b/src/containers/magazine/TabMagazineViewContainer.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import Image from 'next/image';
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { useRecoilState, useResetRecoilState } from 'recoil';
 
 import { useDeleteMagazines, useGetMagazines } from '@/application/hooks/api/magazine';
@@ -59,14 +59,16 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
 
   // 매거진 삭제
   const mutation = useDeleteMagazines();
-  const handleDeleteIds = () => {
+  const handleDeleteIds = useCallback(() => {
     mutation.mutate(
-      { ids: magazineDeleteList },
+      {
+        ids: magazineDeleteList,
+      },
       {
         onSuccess: () => resetDeleteItem(),
       },
     );
-  };
+  }, [mutation, magazineDeleteList, resetDeleteItem]);
 
   const resetMagazineStates = () => {
     isSelectDeleteBtn(false);
@@ -77,9 +79,9 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
   useEffect(() => {
     if (deleteState === true) {
       handleDeleteIds();
+      setDeleteState(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [deleteState]);
+  }, [deleteState, handleDeleteIds]);
 
   return (
     <Tab>

--- a/src/infra/api/magazine.ts
+++ b/src/infra/api/magazine.ts
@@ -18,8 +18,6 @@ class MagazineApi {
     return this.api.post(`/magazine`, args);
   };
   deleteMagazines = ({ ids }: DeleteMagazineRequest) => {
-    //TODO flat ids array
-    console.log('삭제확인용', `/magazine?ids=${ids}`);
     return this.api.delete(`/magazine?ids=${ids}`);
   };
   getMagazineDetail = ({ id }: GetMagazineDetailRequest) => {

--- a/src/infra/api/magazine.ts
+++ b/src/infra/api/magazine.ts
@@ -19,6 +19,7 @@ class MagazineApi {
   };
   deleteMagazines = ({ ids }: DeleteMagazineRequest) => {
     //TODO flat ids array
+    console.log('삭제확인용', `/magazine?ids=${ids}`);
     return this.api.delete(`/magazine?ids=${ids}`);
   };
   getMagazineDetail = ({ id }: GetMagazineDetailRequest) => {


### PR DESCRIPTION
## 📮 관련 이슈
- Resolved: #이슈번호

## ⛳️ 작업 내용

매거진 페이지 삭제 기능을 위한 작업을 했습니다.
- [x] 매거진 다중 선택 UI 제작(이미 구현되어 있는 스크랩 다중 선택 참고)
- [x] 다중 선택 시 Link 영향을 받지 않도록 조건문을 통해 관리
- [x] 선택 버튼, 매거진 ids 배열을 recoil을 통해 관리 (선택을 취소할 시 ids 초기화, 선택했던 매거진 취소 시 ids에서 제외됨)
- [x] magazine delete API 호출 + 삭제 확인 완료

## 🌱 PR 포인트

## 📸 스크린샷
|스크린샷|
|:--:|
|![ezgif com-gif-maker](https://user-images.githubusercontent.com/81777778/211183560-d895f48f-426a-4cc9-8d89-6cb72bf0411b.gif)|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->