### PR TITLE
:sparkles: Feat: 스크랩 상세 페이지 하이퍼링크

### DIFF
--- a/src/components/scrap/Content/SwipeBackground.tsx
+++ b/src/components/scrap/Content/SwipeBackground.tsx
@@ -1,8 +1,12 @@
 import { css } from '@emotion/react';
 import Image from 'next/image';
+import Link from 'next/link';
 import React from 'react';
 
-type SwipeBackgroundProps = { type: 'image' | 'link'; src?: string } | { type: 'text'; text?: string };
+type SwipeBackgroundProps =
+  | { type: 'image'; src?: string }
+  | { type: 'text'; text?: string }
+  | { type: 'link'; src?: string; href: string };
 
 const SwipeBackground = (props: SwipeBackgroundProps) => {
   return (
@@ -17,7 +21,7 @@ const SwipeBackground = (props: SwipeBackgroundProps) => {
         margin: auto;
       `}
     >
-      {props.type === 'image' || props.type === 'link' ? (
+      {props.type === 'image' ? (
         <Image priority src={props.src || '/icon/scrap/defaultCategory.svg'} layout="fill" objectFit={'cover'} />
       ) : props.type === 'text' ? (
         <span
@@ -37,8 +41,13 @@ const SwipeBackground = (props: SwipeBackgroundProps) => {
         >
           {props.text}
         </span>
-      ) : // TODO link preview
-      null}
+      ) : (
+        <Link href={props.href}>
+          <a rel="noopener noreferrer" target="_blank">
+            <Image priority src={props.src || '/icon/scrap/defaultCategory.svg'} layout="fill" objectFit={'cover'} />
+          </a>
+        </Link>
+      )}
     </div>
   );
 };

--- a/src/pages/scrap/[id].tsx
+++ b/src/pages/scrap/[id].tsx
@@ -34,7 +34,7 @@ const ShowScrap: NextPage = () => {
       ? { text: scrap?.content, type: scrapType }
       : scrapType === 'image'
       ? { src: scrap?.file_url, type: scrapType }
-      : { src: scrap?.url_preview, type: scrapType };
+      : { src: scrap?.url_preview, type: scrapType, href: scrap?.content || '' };
 
   return (
     <>


### PR DESCRIPTION
## 📮 관련 이슈
- Resolved: #이슈번호

## ⛳️ 작업 내용
![image](https://user-images.githubusercontent.com/74011724/210837463-2bea37d0-dca0-4d5e-bfd9-410012962aaf.png)
`link` 타입인 스크랩 콘텐츠 배경화면 클릭 시 해당 페이지가 새 탭으로 열립니다
- 매거진 페이지에선 링크 콘텐츠여도 프리뷰 이미지만 응답돼서 위 로직 구현은 못했습니다


## 🌱 PR 포인트

- 테스트 아이디 
    - sh@sh.com
    - 123!@#qwe
- vercel 팀 초대가 pro 버전만 되네요 😥
    - `yarn lint`, `yarn tsc`가 모두 성공해야 preview 배포되니 참고하시길 바랍니다~
    - commit 전에 위 작업을 자동화해주는 `husky` 툴을 활용하는 것도 좋겠네요

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->