### PR TITLE
:bug: Fix: reissue api 무한 요청 수정

### DIFF
--- a/src/infra/api/auth.ts
+++ b/src/infra/api/auth.ts
@@ -1,7 +1,7 @@
 import { instance } from '@/infra/api/instance';
-import type { LoginRequest, Logout, SignUpRequest, SNSLoginRequest } from '@/infra/api/types/auth';
+import type { LoginRequest, Logout, ReIssueRequest, SignUpRequest, SNSLoginRequest } from '@/infra/api/types/auth';
 
-class AuthApi {
+export class AuthApi {
   constructor(private api: typeof instance) {}
   logout = () => {
     return this.api.post<Logout>('/log-out');
@@ -12,8 +12,8 @@ class AuthApi {
   signup = (args: SignUpRequest) => {
     return this.api.post('/auth/sign-up', args);
   };
-  reissue = () => {
-    return this.api.post('/auth/reissue');
+  reissue = ({ retry }: ReIssueRequest) => {
+    return this.api.post('/auth/reissue', null, { headers: { retry } });
   };
   snsLogin = (arg: SNSLoginRequest) => {
     const parameter = (Object.keys(arg) as (keyof SNSLoginRequest)[]).reduce(

--- a/src/infra/api/instance.ts
+++ b/src/infra/api/instance.ts
@@ -48,22 +48,22 @@ instance.interceptors.response.use(
     console.log('✅response :: ', res);
     return res;
   },
-  (err) => {
+  async (err) => {
     if (axios.isAxiosError(err)) {
       const status = err.response?.status;
       const origin = err.config as AxiosRequestConfig;
 
       if (status == 401 && !origin.headers?.retry) {
-        return auth.reissue().then((res) => {
-          if (res.headers.authorization && res.status === 200) {
-            const token = res.headers.authorization.slice(7);
-            setAccessToken(token);
-            return instance({
-              ...origin,
-              headers: { ...origin.headers, authorization: `Bearer ${token}`, retry: true },
-            });
-          }
-        });
+        const res = await auth.reissue({ retry: true });
+
+        if (res.headers.authorization && res.status === 200) {
+          const token = res.headers.authorization.slice(7);
+          setAccessToken(token);
+          return instance({
+            ...origin,
+            headers: { ...origin.headers, authorization: `Bearer ${token}`, retry: true },
+          });
+        }
       }
     }
     return Promise.reject(err);

--- a/src/infra/api/types/auth.ts
+++ b/src/infra/api/types/auth.ts
@@ -23,3 +23,7 @@ export interface SNSLoginResponse {
   data: Record<string, unknown>;
   message: string;
 }
+
+export interface ReIssueRequest {
+  retry?: boolean;
+}


### PR DESCRIPTION
## 📮 관련 이슈
- Resolved: #이슈번호

## ⛳️ 작업 내용
`reissue` api가 401 응답으로 무한요청되는 현상 수정
- reissue api header에 `retry` 값을 추가로 넣어줬습니다

저번에 바뀐 쿠키 기반(HttpOnly, Secure) 리프레시 토큰은 api 요청 보낼때 자동으로 같이 보내지므로(withCredentials)
따로 프론트에서 작업 사항 없습니다!


<!-- 작업한 사항을 간략하게 적어주세요 -->

## 🌱 PR 포인트
![image](https://user-images.githubusercontent.com/74011724/210840818-5b6a9108-b2ef-417a-ab44-7e8d703a61d4.png)
- reissue api 500에러가 자주뜨네요....
    - 테스트 환경 : accessToken: null, refreshToken은 signin api로 쿠키에 저장된 값

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->