### PR TITLE
Design: 매거진 첫 페이지 프로필 UI 스타일링

### DIFF
--- a/src/components/magazine/MagazinePageProfile/index.tsx
+++ b/src/components/magazine/MagazinePageProfile/index.tsx
@@ -1,0 +1,90 @@
+import { css } from '@emotion/react';
+import Image from 'next/image';
+
+import Chip from '@/components/common/Chip';
+import RoundPhoto from '@/components/common/Photo/RoundPhoto';
+
+interface ProfileProps {
+  src: string;
+  name: string;
+  description?: string;
+  hashtags?: string[];
+}
+
+const MagazinePageProfile = ({ src, name, description, hashtags }: ProfileProps) => {
+  return (
+    <section
+      css={css`
+        height: 100%;
+      `}
+    >
+      <div css={MagazineProfileWrap}>
+        <div
+          css={css`
+            margin: 21px 0 9px 0;
+          `}
+        >
+          <RoundPhoto width={'132px'} height={'132px'} src={src} />
+        </div>
+        <div>
+          <span
+            css={(theme) =>
+              css`
+                ${theme.font.B_POINT_17};
+                letter-spacing: 0.005em;
+                line-height: 26px;
+                margin-bottom: 16px;
+              `
+            }
+          >
+            {name}&nbsp;
+          </span>
+          <span
+            css={(theme) =>
+              css`
+                ${theme.font.M_BODY_17};
+              `
+            }
+          >
+            님
+          </span>
+        </div>
+        <div
+          css={(theme) =>
+            css`
+              width: 308px;
+              ${theme.font.R_BODY_12};
+              color: ${theme.color.gray05};
+              letter-spacing: 0.005em;
+              line-height: 22.5px;
+              margin-bottom: 56px;
+              text-align: center;
+            `
+          }
+        >
+          {description}
+        </div>
+        <div
+          css={css`
+            display: flex;
+            gap: 6px;
+          `}
+        >
+          {hashtags?.map((tag) => (
+            <Chip size={'large'} key={tag}>
+              {tag}
+            </Chip>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+};
+
+const MagazineProfileWrap = css`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+`;
+
+export default MagazinePageProfile;

--- a/src/containers/magazine/PageViewContainer.tsx
+++ b/src/containers/magazine/PageViewContainer.tsx
@@ -5,8 +5,9 @@ import Link from 'next/link';
 import React from 'react';
 
 import { getValidURL } from '@/application/utils/helper';
-import { PAGES } from '@/application/utils/mock';
+import { PAGES, PROFILE } from '@/application/utils/mock';
 import Photo from '@/components/common/Photo';
+import MagazinePageProfile from '@/components/magazine/MagazinePageProfile';
 
 interface Props {
   pages: Page[];
@@ -24,6 +25,8 @@ const PageViewContainer = ({ pages = PAGES }: Props) => {
         <ol css={CSSCarouselContainer}>
           {pages.map((page, idx) => (
             <li key={page.page_id} id={`${idx}`} css={CSSCarouselItem}>
+              {/* 캐러셀 사진, 콘텐츠 자리 */}
+              {/* <MagazinePageProfile {...PROFILE} /> */}
               <Photo
                 src={page.file_url || getValidURL(page.contents).toString()}
                 text={page.contents}

--- a/src/containers/magazine/PageViewContainer.tsx
+++ b/src/containers/magazine/PageViewContainer.tsx
@@ -22,30 +22,34 @@ const PageViewContainer = ({ pages = PAGES }: Props) => {
           height: 100%;
         `}
       >
-        <ol css={CSSCarouselContainer}>
-          {pages.map((page, idx) => (
-            <li key={page.page_id} id={`${idx}`} css={CSSCarouselItem}>
-              {idx === 0 ? (
-                <MagazinePageProfile {...PROFILE} />
-              ) : (
-                <>
-                  {' '}
-                  <Photo
-                    src={page.file_url || getValidURL(page.contents).toString()}
-                    text={page.contents}
-                    height={'45vh'}
-                  />
-                  <p css={CSSPageContent}>{page.text}</p>
-                </>
-              )}
-              <div css={CSSSnapper} />
-              <div css={CSSCarouselHandle}>
-                <Link href={{ hash: `#${idx === 0 ? pages.length - 1 : idx - 1}` }}>Prev Item</Link>
-                <Link href={{ hash: `#${idx === pages.length - 1 ? 0 : idx + 1}` }}>Next Item</Link>
-              </div>
-            </li>
-          ))}
-        </ol>
+        {pages.length === 0 ? (
+          <MagazinePageProfile {...PROFILE} />
+        ) : (
+          <ol css={CSSCarouselContainer}>
+            {pages.map((page, idx) => (
+              <li key={page.page_id} id={`${idx}`} css={CSSCarouselItem}>
+                {idx === 0 ? (
+                  <MagazinePageProfile {...PROFILE} />
+                ) : (
+                  <>
+                    {' '}
+                    <Photo
+                      src={page.file_url || getValidURL(page.contents).toString()}
+                      text={page.contents}
+                      height={'45vh'}
+                    />
+                    <p css={CSSPageContent}>{page.text}</p>
+                  </>
+                )}
+                <div css={CSSSnapper} />
+                <div css={CSSCarouselHandle}>
+                  <Link href={{ hash: `#${idx === 0 ? pages.length - 1 : idx - 1}` }}>Prev Item</Link>
+                  <Link href={{ hash: `#${idx === pages.length - 1 ? 0 : idx + 1}` }}>Next Item</Link>
+                </div>
+              </li>
+            ))}
+          </ol>
+        )}
       </article>
       <div
         css={css`
@@ -53,8 +57,8 @@ const PageViewContainer = ({ pages = PAGES }: Props) => {
           pointer-events: none;
         `}
       >
-        <Image src={'/icon/magazine/prevPage.svg'} width={48} height={48} />
-        <Image src={'/icon/magazine/nextPage.svg'} width={48} height={48} />
+        <Image src={'/icon/magazine/prevPage.svg'} width={48} height={48} alt="prevPageBtn" />
+        <Image src={'/icon/magazine/nextPage.svg'} width={48} height={48} alt="nextPageBtn" />
       </div>
     </>
   );

--- a/src/containers/magazine/PageViewContainer.tsx
+++ b/src/containers/magazine/PageViewContainer.tsx
@@ -11,9 +11,12 @@ import MagazinePageProfile from '@/components/magazine/MagazinePageProfile';
 
 interface Props {
   pages: Page[];
+  magazineId: number | undefined;
 }
 
-const PageViewContainer = ({ pages = PAGES }: Props) => {
+const PageViewContainer = ({ pages = PAGES, magazineId }: Props) => {
+  console.log(magazineId);
+
   return (
     <>
       <article
@@ -22,34 +25,31 @@ const PageViewContainer = ({ pages = PAGES }: Props) => {
           height: 100%;
         `}
       >
-        {pages.length === 0 ? (
-          <MagazinePageProfile {...PROFILE} />
-        ) : (
-          <ol css={CSSCarouselContainer}>
-            {pages.map((page, idx) => (
-              <li key={page.page_id} id={`${idx}`} css={CSSCarouselItem}>
-                {idx === 0 ? (
-                  <MagazinePageProfile {...PROFILE} />
-                ) : (
-                  <>
-                    {' '}
-                    <Photo
-                      src={page.file_url || getValidURL(page.contents).toString()}
-                      text={page.contents}
-                      height={'45vh'}
-                    />
-                    <p css={CSSPageContent}>{page.text}</p>
-                  </>
-                )}
-                <div css={CSSSnapper} />
-                <div css={CSSCarouselHandle}>
-                  <Link href={{ hash: `#${idx === 0 ? pages.length - 1 : idx - 1}` }}>Prev Item</Link>
-                  <Link href={{ hash: `#${idx === pages.length - 1 ? 0 : idx + 1}` }}>Next Item</Link>
-                </div>
-              </li>
-            ))}
-          </ol>
-        )}
+        <ol css={CSSCarouselContainer}>
+          <li css={CSSCarouselItem}>
+            <MagazinePageProfile {...PROFILE} />
+            <div css={CSSSnapper} />
+            <div css={CSSCarouselHandle}>
+              <Link href={{ hash: `#${pages.length}` }}>Prev Item</Link>
+              <Link href={{ hash: `#1` }}>Next Item</Link>
+            </div>
+          </li>
+          {pages.map((page, idx) => (
+            <li key={page.page_id} id={`${idx + 1}`} css={CSSCarouselItem}>
+              <Photo
+                src={page.file_url || getValidURL(page.contents).toString()}
+                text={page.contents}
+                height={'45vh'}
+              />
+              <p css={CSSPageContent}>{page.text}</p>
+              <div css={CSSSnapper} />
+              <div css={CSSCarouselHandle}>
+                <Link href={{ hash: `#${idx === 0 ? pages.length : idx}` }}>Prev Item</Link>
+                <Link href={{ hash: `#${idx === pages.length - 1 ? 1 : idx + 2}` }}>Next Item</Link>
+              </div>
+            </li>
+          ))}
+        </ol>
       </article>
       <div
         css={css`
@@ -116,4 +116,5 @@ const CSSSnapper = css`
   height: 100%;
   scroll-snap-align: center;
 `;
+
 export default PageViewContainer;

--- a/src/containers/magazine/PageViewContainer.tsx
+++ b/src/containers/magazine/PageViewContainer.tsx
@@ -25,14 +25,19 @@ const PageViewContainer = ({ pages = PAGES }: Props) => {
         <ol css={CSSCarouselContainer}>
           {pages.map((page, idx) => (
             <li key={page.page_id} id={`${idx}`} css={CSSCarouselItem}>
-              {/* 캐러셀 사진, 콘텐츠 자리 */}
-              {/* <MagazinePageProfile {...PROFILE} /> */}
-              <Photo
-                src={page.file_url || getValidURL(page.contents).toString()}
-                text={page.contents}
-                height={'45vh'}
-              />
-              <p css={CSSPageContent}>{page.text}</p>
+              {idx === 0 ? (
+                <MagazinePageProfile {...PROFILE} />
+              ) : (
+                <>
+                  {' '}
+                  <Photo
+                    src={page.file_url || getValidURL(page.contents).toString()}
+                    text={page.contents}
+                    height={'45vh'}
+                  />
+                  <p css={CSSPageContent}>{page.text}</p>
+                </>
+              )}
               <div css={CSSSnapper} />
               <div css={CSSCarouselHandle}>
                 <Link href={{ hash: `#${idx === 0 ? pages.length - 1 : idx - 1}` }}>Prev Item</Link>

--- a/src/pages/magazine/[id].tsx
+++ b/src/pages/magazine/[id].tsx
@@ -56,7 +56,7 @@ const ShowMagazine: NextPage = () => {
           {magazine && `${magazine.created_date[0]}. ${magazine.created_date[1]}. ${magazine.created_date[2]}`}
         </span>
       </div>
-      <PageViewContainer pages={magazine?.page_list || []} />
+      <PageViewContainer pages={magazine?.page_list || []} magazineId={magazine?.magazine_id} />
     </>
   );
 };


### PR DESCRIPTION
## 📮 관련 이슈
- Resolved: #이슈번호

## ⛳️ 작업 내용

각 매거진 진입 시 보여줄 프로필 UI를 완성했습니다.

## 🌱 PR 포인트

1/6(금) 스프린트 회의 때, 페이지 descripon 부분은 프로필에 적용된 소개로 우선 가져온 뒤 매거진 별로 소개글을 수정할 수 있도록 하자는 의견이 나왔습니다.
🛠 해당 부분은 추후 코드 수정이 필요합니다.

## 📸 스크린샷
|스크린샷|
|:--:|
|![ezgif com-gif-maker](https://user-images.githubusercontent.com/81777778/211156974-6db356ec-f3e5-4b8b-b6f3-6e6b9a28e911.gif)|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->