### PR TITLE
:lipstick: 매거진 페이지 삭제 UI 스타일링/삭제 기능 제작

### DIFF
--- a/src/application/store/magazine/hook.ts
+++ b/src/application/store/magazine/hook.ts
@@ -2,9 +2,9 @@ import { useRecoilState, useRecoilValue, useResetRecoilState, useSetRecoilState 
 
 import {
   deleteMagazineList,
-  deletePageList,
   magazineInfoSelector,
   magazineState,
+  pageDeleteList,
   pageSelector,
 } from '@/application/store/magazine/state';
 
@@ -14,4 +14,4 @@ export const useMagazineInfo = () => useRecoilValue(magazineState);
 export const useResetMagazineInfo = () => useResetRecoilState(magazineState);
 
 export const useMagazineDeleteList = () => useRecoilValue(deleteMagazineList);
-export const usePageDeleteList = () => useRecoilValue(deletePageList);
+export const usePageDeleteList = () => useRecoilValue(pageDeleteList);

--- a/src/application/store/magazine/hook.ts
+++ b/src/application/store/magazine/hook.ts
@@ -2,6 +2,7 @@ import { useRecoilState, useRecoilValue, useResetRecoilState, useSetRecoilState 
 
 import {
   deleteMagazineList,
+  deletePageList,
   magazineInfoSelector,
   magazineState,
   pageSelector,
@@ -11,4 +12,6 @@ export const useSetMagazineInfo = () => useSetRecoilState(magazineInfoSelector);
 export const usePage = (id: number) => useRecoilState(pageSelector(id));
 export const useMagazineInfo = () => useRecoilValue(magazineState);
 export const useResetMagazineInfo = () => useResetRecoilState(magazineState);
+
 export const useMagazineDeleteList = () => useRecoilValue(deleteMagazineList);
+export const usePageDeleteList = () => useRecoilValue(deletePageList);

--- a/src/application/store/magazine/state.ts
+++ b/src/application/store/magazine/state.ts
@@ -57,7 +57,7 @@ export const magazineInfoSelector = selector<Partial<MagazineState>>({
 });
 
 export const multiDelete = atom({
-  key: 'deleteOption',
+  key: 'multiDelete',
   default: false,
 });
 
@@ -69,5 +69,18 @@ export const magazineIdsArray = atom<Array<number>>({
 export const deleteMagazineList = selector({
   key: 'deleteMagazineList',
   get: ({ get }) => get(magazineIdsArray),
-  set: ({ set }, newValue) => set(magazineIdsArray, (prevValue) => ({ ...prevValue, ...newValue })),
+  set: ({ set }, newValue) =>
+    !(newValue instanceof DefaultValue) && set(magazineIdsArray, (prevValue) => [...prevValue, ...newValue]),
+});
+
+export const pageIdsArray = atom<Array<number>>({
+  key: 'pageIdsArray',
+  default: [],
+});
+
+export const deletePageList = selector({
+  key: 'deletePageList',
+  get: ({ get }) => get(pageIdsArray),
+  set: ({ set }, newValue) =>
+    !(newValue instanceof DefaultValue) && set(magazineIdsArray, (prevValue) => [...prevValue, ...newValue]),
 });

--- a/src/application/store/magazine/state.ts
+++ b/src/application/store/magazine/state.ts
@@ -82,5 +82,5 @@ export const deletePageList = selector({
   key: 'deletePageList',
   get: ({ get }) => get(pageIdsArray),
   set: ({ set }, newValue) =>
-    !(newValue instanceof DefaultValue) && set(magazineIdsArray, (prevValue) => [...prevValue, ...newValue]),
+    !(newValue instanceof DefaultValue) && set(pageIdsArray, (prevValue) => [...prevValue, ...newValue]),
 });

--- a/src/application/store/magazine/state.ts
+++ b/src/application/store/magazine/state.ts
@@ -78,8 +78,8 @@ export const pageIdsArray = atom<Array<number>>({
   default: [],
 });
 
-export const deletePageList = selector({
-  key: 'deletePageList',
+export const pageDeleteList = selector({
+  key: 'pageDeleteList',
   get: ({ get }) => get(pageIdsArray),
   set: ({ set }, newValue) =>
     !(newValue instanceof DefaultValue) && set(pageIdsArray, (prevValue) => [...prevValue, ...newValue]),

--- a/src/components/magazine/PageList/index.tsx
+++ b/src/components/magazine/PageList/index.tsx
@@ -11,8 +11,6 @@ interface Props {
 }
 
 const PageList = ({ pages, selectItem }: Props) => {
-  console.log('페이지 정보들', pages);
-
   // 썸네일 클릭 시 해당 id 추가, 선택 취소 시 id 확인 후 제거
   const setPageItems = useSetRecoilState(pageIdsArray);
   const pickSet = useRef(new Set<number>());
@@ -35,7 +33,7 @@ const PageList = ({ pages, selectItem }: Props) => {
       `}
     >
       {pages.map((page, idx) => (
-        <div key={idx} onClick={() => selectItem && selectPageItems(page.scrap_id)}>
+        <div key={idx} onClick={() => selectItem && selectPageItems(page.scrap_id!)}>
           <PageListItem item={page} ratio={'100/134'} onClick={page.onClick} selectItem={selectItem} />
         </div>
       ))}

--- a/src/components/magazine/PageList/index.tsx
+++ b/src/components/magazine/PageList/index.tsx
@@ -4,8 +4,9 @@ import PageListItem from '@/components/magazine/PhotoListItem';
 
 interface Props {
   pages: (MagazineThumbnail & { onClick?: () => void })[];
+  selectItem?: boolean;
 }
-const PageList = ({ pages }: Props) => {
+const PageList = ({ pages, selectItem }: Props) => {
   return (
     <div
       css={css`
@@ -16,7 +17,7 @@ const PageList = ({ pages }: Props) => {
       `}
     >
       {pages.map((page, idx) => (
-        <PageListItem key={idx} item={page} ratio={'100/134'} onClick={page.onClick} />
+        <PageListItem key={idx} item={page} ratio={'100/134'} onClick={page.onClick} selectItem={selectItem} />
       ))}
     </div>
   );

--- a/src/components/magazine/PageList/index.tsx
+++ b/src/components/magazine/PageList/index.tsx
@@ -33,8 +33,15 @@ const PageList = ({ pages, selectItem }: Props) => {
       `}
     >
       {pages.map((page, idx) => (
-        <div key={idx} onClick={() => selectItem && selectPageItems(page.scrap_id!)}>
-          <PageListItem item={page} ratio={'100/134'} onClick={page.onClick} selectItem={selectItem} />
+        <div
+          key={idx}
+          onClick={() => selectItem && idx !== 0 && idx !== pages.length - 1 && selectPageItems(page.scrap_id!)}
+        >
+          {idx === 0 || idx === pages.length - 1 ? (
+            <PageListItem item={page} ratio={'100/134'} pages={pages} />
+          ) : (
+            <PageListItem item={page} ratio={'100/134'} onClick={page.onClick} selectItem={selectItem} pages={pages} />
+          )}
         </div>
       ))}
     </div>

--- a/src/components/magazine/PageList/index.tsx
+++ b/src/components/magazine/PageList/index.tsx
@@ -1,12 +1,30 @@
 import { css } from '@emotion/react';
+import { useCallback, useRef } from 'react';
+import { useSetRecoilState } from 'recoil';
 
+import { pageIdsArray } from '@/application/store/magazine/state';
 import PageListItem from '@/components/magazine/PhotoListItem';
 
 interface Props {
   pages: (MagazineThumbnail & { onClick?: () => void })[];
   selectItem?: boolean;
 }
+
 const PageList = ({ pages, selectItem }: Props) => {
+  console.log('페이지 정보들', pages);
+
+  // 썸네일 클릭 시 해당 id 추가, 선택 취소 시 id 확인 후 제거
+  const setPageItems = useSetRecoilState(pageIdsArray);
+  const pickSet = useRef(new Set<number>());
+
+  const selectPageItems = useCallback(
+    (id: number) => {
+      pickSet.current.has(id) ? pickSet.current.delete(id) : pickSet.current.add(id);
+      setPageItems(Array.from(pickSet.current));
+    },
+    [pickSet, setPageItems],
+  );
+
   return (
     <div
       css={css`
@@ -17,7 +35,9 @@ const PageList = ({ pages, selectItem }: Props) => {
       `}
     >
       {pages.map((page, idx) => (
-        <PageListItem key={idx} item={page} ratio={'100/134'} onClick={page.onClick} selectItem={selectItem} />
+        <div key={idx} onClick={() => selectItem && selectPageItems(page.scrap_id)}>
+          <PageListItem item={page} ratio={'100/134'} onClick={page.onClick} selectItem={selectItem} />
+        </div>
       ))}
     </div>
   );

--- a/src/components/magazine/PageList/index.tsx
+++ b/src/components/magazine/PageList/index.tsx
@@ -38,9 +38,9 @@ const PageList = ({ pages, selectItem }: Props) => {
           onClick={() => selectItem && idx !== 0 && idx !== pages.length - 1 && selectPageItems(page.scrap_id!)}
         >
           {idx === 0 || idx === pages.length - 1 ? (
-            <PageListItem item={page} ratio={'100/134'} pages={pages} />
+            <PageListItem item={page} ratio={'100/134'} />
           ) : (
-            <PageListItem item={page} ratio={'100/134'} onClick={page.onClick} selectItem={selectItem} pages={pages} />
+            <PageListItem item={page} ratio={'100/134'} onClick={page.onClick} selectItem={selectItem} />
           )}
         </div>
       ))}

--- a/src/components/magazine/PhotoListItem/index.tsx
+++ b/src/components/magazine/PhotoListItem/index.tsx
@@ -9,6 +9,7 @@ interface Props {
   width?: string;
   height?: string;
   ratio?: string;
+  pages?: MagazineThumbnail[];
   onClick?: () => void;
 }
 const PhotoListItem = ({ item, selectItem, ratio, ...rest }: Props) => {

--- a/src/components/magazine/PhotoListItem/index.tsx
+++ b/src/components/magazine/PhotoListItem/index.tsx
@@ -9,7 +9,6 @@ interface Props {
   width?: string;
   height?: string;
   ratio?: string;
-  pages?: MagazineThumbnail[];
   onClick?: () => void;
 }
 const PhotoListItem = ({ item, selectItem, ratio, ...rest }: Props) => {

--- a/src/containers/magazine/MagazineCreateContainer.tsx
+++ b/src/containers/magazine/MagazineCreateContainer.tsx
@@ -74,7 +74,7 @@ const MagazineCreateContainer = ({ thumbnails, selectItem }: Props) => {
               position: relative;
             `}
           >
-            <Image src={'/icon/edit.svg'} layout={'fill'} objectFit={'cover'} />
+            <Image src={'/icon/edit.svg'} layout={'fill'} objectFit={'cover'} alt="편집아이콘" />
           </button>
         </span>
         <span

--- a/src/containers/magazine/MagazineCreateContainer.tsx
+++ b/src/containers/magazine/MagazineCreateContainer.tsx
@@ -13,8 +13,9 @@ import PageList from '@/components/magazine/PageList';
 
 interface Props {
   thumbnails: MagazineThumbnail[];
+  selectItem?: boolean;
 }
-const MagazineCreateContainer = ({ thumbnails }: Props) => {
+const MagazineCreateContainer = ({ thumbnails, selectItem }: Props) => {
   const { show: modal } = useModal();
   const magazineInfo = useMagazineInfo();
   const setMagazineInfo = useSetMagazineInfo();
@@ -91,7 +92,7 @@ const MagazineCreateContainer = ({ thumbnails }: Props) => {
           <Switch defaultChecked={!magazineInfo.open_status} onClick={(p) => setMagazineInfo({ open_status: !p })} />
         </span>
       </div>
-      <PageList pages={thumbnails} />
+      <PageList pages={thumbnails} selectItem={selectItem} />
     </>
   );
 };

--- a/src/containers/magazine/PageViewContainer.tsx
+++ b/src/containers/magazine/PageViewContainer.tsx
@@ -11,12 +11,9 @@ import MagazinePageProfile from '@/components/magazine/MagazinePageProfile';
 
 interface Props {
   pages: Page[];
-  magazineId: number | undefined;
 }
 
-const PageViewContainer = ({ pages = PAGES, magazineId }: Props) => {
-  console.log(magazineId);
-
+const PageViewContainer = ({ pages = PAGES }: Props) => {
   return (
     <>
       <article

--- a/src/containers/magazine/PageViewContainer.tsx
+++ b/src/containers/magazine/PageViewContainer.tsx
@@ -11,6 +11,7 @@ import MagazinePageProfile from '@/components/magazine/MagazinePageProfile';
 
 interface Props {
   pages: Page[];
+  magazineId: number | undefined;
 }
 
 const PageViewContainer = ({ pages = PAGES }: Props) => {

--- a/src/infra/api/magazine.ts
+++ b/src/infra/api/magazine.ts
@@ -27,7 +27,6 @@ class MagazineApi {
     return this.api.put(`/magazine/${id}`, rest);
   };
   deletePages = ({ ids }: DeletePageRequest) => {
-    //TODO flat ids array
     return this.api.delete(`/magazine/page?ids=${ids}`);
   };
   checkTitle = (title: string) => {

--- a/src/pages/magazine/edit/[id].tsx
+++ b/src/pages/magazine/edit/[id].tsx
@@ -8,7 +8,12 @@ import { useUpdateMagazine } from '@/application/hooks/api/magazine';
 import usePopup from '@/application/hooks/common/usePopup';
 import useToast from '@/application/hooks/common/useToast';
 import { useEditPageReset, useEditPageSet } from '@/application/store/edit/hook';
-import { useMagazineInfo, useResetMagazineInfo, useSetMagazineInfo } from '@/application/store/magazine/hook';
+import {
+  useMagazineInfo,
+  usePageDeleteList,
+  useResetMagazineInfo,
+  useSetMagazineInfo,
+} from '@/application/store/magazine/hook';
 import SelectCategoryWithContent from '@/components/category/Select/SelectCategoryWithContent';
 import { ActiveButton } from '@/components/common/Button';
 import { DeletePopup } from '@/components/common/Popup/Sentence';
@@ -27,6 +32,9 @@ const EditMagazine: NextPage = () => {
   const mutation = useUpdateMagazine();
   const resetMagazineInfo = useResetMagazineInfo();
   const resetEditPage = useEditPageReset();
+
+  const pageDeleteItem = usePageDeleteList();
+  console.log(pageDeleteItem);
 
   // 스크랩, 매거진 페이지같이 옵션선택이 없으므로 바로 boolean 설정
   const [selected, setSelected] = useState(false);
@@ -64,7 +72,7 @@ const EditMagazine: NextPage = () => {
     const ret: (MagazineThumbnail & { onClick?: () => void })[] = [
       {
         cover_url: coverUrl,
-        title: '1 페이지',
+        title: '표지 변경',
         magazine_id: 0,
         onClick: () =>
           show({
@@ -81,8 +89,9 @@ const EditMagazine: NextPage = () => {
       },
       ...magazineInfo.page_list.map((page, idx) => ({
         cover_url: page.src,
-        title: `${idx + 2} 페이지`,
+        title: `${idx + 1} 페이지`,
         magazine_id: idx,
+        scrap_id: page.scrap_id,
       })),
     ];
 
@@ -148,18 +157,20 @@ const EditMagazine: NextPage = () => {
         </span>
       </div>
       <MagazineCreateContainer thumbnails={pages} selectItem={selected} />
-      <ActiveButton
-        active={!!coverUrl}
-        onClick={handleComplete}
-        custom={css`
-          margin-top: auto;
-        `}
-      >
-        완료
-      </ActiveButton>
-      {selected && <DeleteNavigation onClick={showDeletePagesToast} />}
+      {selected === true ? (
+        <DeleteNavigation onClick={showDeletePagesToast} />
+      ) : (
+        <ActiveButton
+          active={!!coverUrl}
+          onClick={handleComplete}
+          custom={css`
+            margin-top: auto;
+          `}
+        >
+          완료
+        </ActiveButton>
+      )}
     </>
   );
 };
-
 export default EditMagazine;

--- a/src/pages/magazine/edit/[id].tsx
+++ b/src/pages/magazine/edit/[id].tsx
@@ -5,11 +5,16 @@ import { useRouter } from 'next/router';
 import React, { useMemo, useState } from 'react';
 
 import { useUpdateMagazine } from '@/application/hooks/api/magazine';
+import usePopup from '@/application/hooks/common/usePopup';
 import useToast from '@/application/hooks/common/useToast';
 import { useEditPageReset, useEditPageSet } from '@/application/store/edit/hook';
 import { useMagazineInfo, useResetMagazineInfo, useSetMagazineInfo } from '@/application/store/magazine/hook';
 import SelectCategoryWithContent from '@/components/category/Select/SelectCategoryWithContent';
 import { ActiveButton } from '@/components/common/Button';
+import { DeletePopup } from '@/components/common/Popup/Sentence';
+import DeleteNavigation from '@/components/scrap/DeleteNavigation';
+import { DeleteScrapToast } from '@/components/scrap/Toast';
+import { useBottomNavigationContext } from '@/containers/HOC/NavigationContext';
 import MagazineCreateContainer from '@/containers/magazine/MagazineCreateContainer';
 
 /**
@@ -27,6 +32,23 @@ const EditMagazine: NextPage = () => {
   const mutation = useUpdateMagazine();
   const resetMagazineInfo = useResetMagazineInfo();
   const resetEditPage = useEditPageReset();
+
+  // 스크랩, 매거진 페이지같이 옵션선택이 없으므로 바로 boolean 설정
+  const [selected, setSelected] = useState(false);
+  const setNavigation = useBottomNavigationContext()[1];
+  const popup = usePopup();
+
+  const handleDeletePages = () => {
+    setSelected(false);
+    popup(DeletePopup, 'success');
+  };
+
+  const showDeletePagesToast = () => show({ content: <DeleteScrapToast onDelete={handleDeletePages} /> });
+
+  const handleMultiSelect = () => {
+    setSelected(true);
+    selected ? setNavigation('default') : setNavigation(<DeleteNavigation onClick={showDeletePagesToast} />);
+  };
 
   const handleBack = () => {
     router.replace(`/magazine/${id}`).then(() => {
@@ -118,6 +140,7 @@ const EditMagazine: NextPage = () => {
           <Image src={'/icon/backArrow.svg'} layout={'fill'} objectFit={'cover'} />
         </span>
         <span
+          onClick={handleMultiSelect}
           css={(theme) =>
             css`
               ${theme.font.R_BODY_15};
@@ -128,7 +151,7 @@ const EditMagazine: NextPage = () => {
             `
           }
         >
-          <Image src={'/icon/multiSelect.svg'} width={18} height={18} />
+          {selected ? '취소' : <Image src={'/icon/multiSelect.svg'} width={18} height={18} alt="삭제아이콘" />}
         </span>
       </div>
       <MagazineCreateContainer thumbnails={pages} />

--- a/src/pages/magazine/edit/[id].tsx
+++ b/src/pages/magazine/edit/[id].tsx
@@ -14,13 +14,8 @@ import { ActiveButton } from '@/components/common/Button';
 import { DeletePopup } from '@/components/common/Popup/Sentence';
 import DeleteNavigation from '@/components/scrap/DeleteNavigation';
 import { DeleteScrapToast } from '@/components/scrap/Toast';
-import { useBottomNavigationContext } from '@/containers/HOC/NavigationContext';
 import MagazineCreateContainer from '@/containers/magazine/MagazineCreateContainer';
 
-/**
- * @todo
- * 수정 페이지 완성
- */
 const EditMagazine: NextPage = () => {
   const router = useRouter();
   const id = router.query.id ? Number(router.query.id) : 0;
@@ -35,7 +30,6 @@ const EditMagazine: NextPage = () => {
 
   // 스크랩, 매거진 페이지같이 옵션선택이 없으므로 바로 boolean 설정
   const [selected, setSelected] = useState(false);
-  const setNavigation = useBottomNavigationContext()[1];
   const popup = usePopup();
 
   const handleDeletePages = () => {
@@ -46,8 +40,7 @@ const EditMagazine: NextPage = () => {
   const showDeletePagesToast = () => show({ content: <DeleteScrapToast onDelete={handleDeletePages} /> });
 
   const handleMultiSelect = () => {
-    setSelected(true);
-    selected ? setNavigation('default') : setNavigation(<DeleteNavigation onClick={showDeletePagesToast} />);
+    setSelected(!selected);
   };
 
   const handleBack = () => {
@@ -137,7 +130,7 @@ const EditMagazine: NextPage = () => {
             left: 0;
           `}
         >
-          <Image src={'/icon/backArrow.svg'} layout={'fill'} objectFit={'cover'} />
+          <Image src={'/icon/backArrow.svg'} layout={'fill'} objectFit={'cover'} alt="뒤로가기" />
         </span>
         <span
           onClick={handleMultiSelect}
@@ -154,7 +147,7 @@ const EditMagazine: NextPage = () => {
           {selected ? '취소' : <Image src={'/icon/multiSelect.svg'} width={18} height={18} alt="삭제아이콘" />}
         </span>
       </div>
-      <MagazineCreateContainer thumbnails={pages} />
+      <MagazineCreateContainer thumbnails={pages} selectItem={selected} />
       <ActiveButton
         active={!!coverUrl}
         onClick={handleComplete}
@@ -164,6 +157,7 @@ const EditMagazine: NextPage = () => {
       >
         완료
       </ActiveButton>
+      {selected && <DeleteNavigation onClick={showDeletePagesToast} />}
     </>
   );
 };

--- a/src/pages/magazine/edit/[id].tsx
+++ b/src/pages/magazine/edit/[id].tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import { useRouter } from 'next/router';
 import React, { useMemo, useState } from 'react';
 
-import { useUpdateMagazine } from '@/application/hooks/api/magazine';
+import { useDeletePages, useUpdateMagazine } from '@/application/hooks/api/magazine';
 import usePopup from '@/application/hooks/common/usePopup';
 import useToast from '@/application/hooks/common/useToast';
 import { useEditPageReset, useEditPageSet } from '@/application/store/edit/hook';
@@ -34,13 +34,13 @@ const EditMagazine: NextPage = () => {
   const resetEditPage = useEditPageReset();
 
   const pageDeleteItem = usePageDeleteList();
-  console.log(pageDeleteItem);
 
   // 스크랩, 매거진 페이지같이 옵션선택이 없으므로 바로 boolean 설정
   const [selected, setSelected] = useState(false);
   const popup = usePopup();
 
   const handleDeletePages = () => {
+    requestDeletePage();
     setSelected(false);
     popup(DeletePopup, 'success');
   };
@@ -49,6 +49,17 @@ const EditMagazine: NextPage = () => {
 
   const handleMultiSelect = () => {
     setSelected(!selected);
+  };
+
+  // 매거진 페이지 삭제
+  const pageMutation = useDeletePages();
+  const requestDeletePage = () => {
+    pageMutation.mutate(
+      { ids: pageDeleteItem },
+      {
+        onSuccess: handleBack,
+      },
+    );
   };
 
   const handleBack = () => {

--- a/src/pages/magazine/edit/[id].tsx
+++ b/src/pages/magazine/edit/[id].tsx
@@ -33,7 +33,7 @@ const EditMagazine: NextPage = () => {
   const resetMagazineInfo = useResetMagazineInfo();
   const resetEditPage = useEditPageReset();
 
-  const pageDeleteItem = usePageDeleteList();
+  const pageDeleteList = usePageDeleteList();
 
   // 스크랩, 매거진 페이지같이 옵션선택이 없으므로 바로 boolean 설정
   const [selected, setSelected] = useState(false);
@@ -55,7 +55,7 @@ const EditMagazine: NextPage = () => {
   const pageMutation = useDeletePages();
   const requestDeletePage = () => {
     pageMutation.mutate(
-      { ids: pageDeleteItem },
+      { ids: pageDeleteList },
       {
         onSuccess: handleBack,
       },
@@ -170,7 +170,7 @@ const EditMagazine: NextPage = () => {
         </span>
       </div>
       <MagazineCreateContainer thumbnails={pages} selectItem={selected} />
-      {selected === true ? (
+      {selected ? (
         <DeleteNavigation onClick={showDeletePagesToast} />
       ) : (
         <ActiveButton

--- a/src/pages/magazine/edit/[id].tsx
+++ b/src/pages/magazine/edit/[id].tsx
@@ -74,6 +74,7 @@ const EditMagazine: NextPage = () => {
         cover_url: coverUrl,
         title: '표지 변경',
         magazine_id: 0,
+        scrap_id: 0,
         onClick: () =>
           show({
             content: (
@@ -99,6 +100,7 @@ const EditMagazine: NextPage = () => {
       cover_url: '/icon/magazine/addPage.svg',
       title: '페이지 추가',
       magazine_id: 0,
+      scrap_id: 0,
       onClick: () =>
         show({
           content: (

--- a/src/pages/magazine/edit/[id].tsx
+++ b/src/pages/magazine/edit/[id].tsx
@@ -86,18 +86,21 @@ const EditMagazine: NextPage = () => {
         title: '표지 변경',
         magazine_id: 0,
         scrap_id: 0,
-        onClick: () =>
-          show({
-            content: (
-              <SelectCategoryWithContent
-                onSubmit={(pages) => {
-                  setCoverUrl(pages.src);
-                  setMagazineInfo({ cover_scrap_id: pages.scrap_id });
-                  close();
-                }}
-              />
-            ),
-          }),
+        onClick: () => {
+          selected
+            ? ''
+            : show({
+                content: (
+                  <SelectCategoryWithContent
+                    onSubmit={(pages) => {
+                      setCoverUrl(pages.src);
+                      setMagazineInfo({ cover_scrap_id: pages.scrap_id });
+                      close();
+                    }}
+                  />
+                ),
+              });
+        },
       },
       ...magazineInfo.page_list.map((page, idx) => ({
         cover_url: page.src,
@@ -112,22 +115,25 @@ const EditMagazine: NextPage = () => {
       title: '페이지 추가',
       magazine_id: 0,
       scrap_id: 0,
-      onClick: () =>
-        show({
-          content: (
-            <SelectCategoryWithContent
-              multiSelect
-              onSubmit={(pages) => {
-                setEditPage(pages);
-                router.push('/magazine/upload/page').then(close);
-              }}
-            />
-          ),
-        }),
+      onClick: () => {
+        selected
+          ? ''
+          : show({
+              content: (
+                <SelectCategoryWithContent
+                  multiSelect
+                  onSubmit={(pages) => {
+                    setEditPage(pages);
+                    router.push('/magazine/upload/page').then(close);
+                  }}
+                />
+              ),
+            });
+      },
     });
 
     return ret;
-  }, [close, coverUrl, magazineInfo.page_list, router, setEditPage, setMagazineInfo, show]);
+  }, [close, coverUrl, magazineInfo.page_list, router, selected, setEditPage, setMagazineInfo, show]);
 
   return (
     <>

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -42,7 +42,7 @@ interface MagazineThumbnail {
   cover_url: string;
   title: string;
   magazine_id: number;
-  scrap_id?: number;
+  scrap_id: number;
   placeholder?: string;
 }
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -42,6 +42,7 @@ interface MagazineThumbnail {
   cover_url: string;
   title: string;
   magazine_id: number;
+  scrap_id?: number;
   placeholder?: string;
 }
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -42,7 +42,7 @@ interface MagazineThumbnail {
   cover_url: string;
   title: string;
   magazine_id: number;
-  scrap_id: number;
+  scrap_id?: number;
   placeholder?: string;
 }
 


### PR DESCRIPTION
## 📮 관련 이슈
- Resolved: #이슈번호

## ⛳️ 작업 내용

- 매거진 다중 선택 UI 제작 + 삭제 버튼 클릭 시 삭제네비게이션 삭제 취소 시 다시 완료버튼
- 매거진 페이지 ids는 recoil을 통해 관리 (선택을 취소할 시 ids 초기화, 선택했던 매거진 취소 시 ids에서 제외됨)
 - page delete API 호출 + 삭제 확인 완료
 - 삭제 후 팝업창과 handleBack으로 해당 매거진 페이지로 이동
 - 삭제 선택 시 표지 변경과 페이지 추가 아이템 같이 비활성화 되어야 하는 요소들에 대한 코드 추가

➕ 수정페이지 들어갔을 때 보이는 첫 번째 PageListItem은 표지 변경을 위한 요소인 것 같아서, 두 번째 아이템부터 1페이지로 시작하도록 다시 작성을 했는데 괜찮을까요? ➡️ 기/디 팀과 이야기 나눠보기

- [x] 삭제 UI 스타일링 완성
- [x] 페이지 삭제 기능 완성

## 🌱 PR 포인트

## 📸 스크린샷
|스크린샷|
|:--:|
|![매거진페이지삭제](https://user-images.githubusercontent.com/81777778/211983404-97362ec4-40ba-4feb-af79-333002330e5a.gif)|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->