### PR TITLE
✨ Feat : 비디오/PDF 콘텐츠 렌더링 & 클릭 시 전체화면

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "react": "18.2.0",
     "react-dom": "18.2.0",
     "react-loader-spinner": "^5.3.4",
+    "react-pdf": "^6.2.2",
     "react-swipeable": "^7.0.0",
     "recoil": "^0.7.6"
   },
@@ -44,6 +45,7 @@
     "@types/node": "18.11.5",
     "@types/react": "18.0.22",
     "@types/react-dom": "18.0.7",
+    "@types/react-pdf": "^6.2.0",
     "@typescript-eslint/eslint-plugin": "^5.41.0",
     "@typescript-eslint/parser": "^5.41.0",
     "babel-loader": "^8.2.5",

--- a/src/application/hooks/common/useWindowSize.ts
+++ b/src/application/hooks/common/useWindowSize.ts
@@ -1,0 +1,27 @@
+import { useEffect, useState } from 'react';
+
+const useWindowSize = () => {
+  const [windowSize, setWindowSize] = useState({
+    width: 0,
+    height: 0,
+  });
+
+  useEffect(() => {
+    if (typeof window !== 'undefined') {
+      const handleResize = () => {
+        setWindowSize({
+          width: Math.min(window.innerWidth, 440), // max window size
+          height: window.innerHeight,
+        });
+      };
+
+      window.addEventListener('resize', handleResize);
+      handleResize();
+
+      return () => window.removeEventListener('resize', handleResize);
+    }
+  }, []);
+  return windowSize;
+};
+
+export default useWindowSize;

--- a/src/application/store/scrap/useScrapForm.ts
+++ b/src/application/store/scrap/useScrapForm.ts
@@ -10,29 +10,26 @@ type HandleScrapArgs =
       data: Pick<ScarpForm, 'category_id'>['category_id'];
     }
   | { type: 'information'; data: Pick<ScarpForm, 'title' | 'hashtags' | 'memo'> }
-  | { type: 'file'; data: Pick<ScarpForm, 'file'>['file'] }
-  | { type: 'link'; data: string }
-  | { type: 'text'; data: string };
+  | { type: 'image' | 'video' | 'pdf'; data: Pick<ScarpForm, 'file'>['file'] }
+  | { type: 'link' | 'text'; data: string };
 
 const useScrapForm = () => {
   const [scrap, setScrap] = useRecoilState(scarpForm);
 
-  // TODO reducer 비슷한데 더 좋은 방법 없을지?
   const handleScrap = useCallback(
     ({ type, data }: HandleScrapArgs) => {
-      console.log('👀 UploadScrapState :::', type, data);
       switch (type) {
         case 'category':
           setScrap((prev) => ({ ...prev, category_id: data }));
           break;
-        case 'file':
-          setScrap((prev) => ({ ...prev, file: data, scrap_type: 'image' }));
+        case 'image':
+        case 'video':
+        case 'pdf':
+          setScrap((prev) => ({ ...prev, file: data, scrap_type: type }));
           break;
         case 'text':
-          setScrap((prev) => ({ ...prev, content: data, scrap_type: 'text' }));
-          break;
         case 'link':
-          setScrap((prev) => ({ ...prev, content: data, scrap_type: 'link' }));
+          setScrap((prev) => ({ ...prev, content: data, scrap_type: type }));
           break;
         case 'information':
           setScrap((prev) => ({ ...prev, ...data }));

--- a/src/application/utils/constant.ts
+++ b/src/application/utils/constant.ts
@@ -17,4 +17,5 @@ export const ERR_CODE = {
 export const ERR_MESSAGE = {
   DUPLICATED_TITLE: '이미 있는 제목입니다.',
   NOT_MODIFY_DEFAULT_CATEGORY: '기본 카테고리는 수정할 수 없습니다.',
+  NOT_SUPPORTED_FILE: '지원되지 않는 파일입니다.',
 } as const;

--- a/src/application/utils/helper.ts
+++ b/src/application/utils/helper.ts
@@ -3,6 +3,8 @@ export const getSrcByType = (content: Scrap | Category) => {
     case 'link':
       return content.url_preview;
     case 'image':
+    case 'video':
+    case 'pdf':
       return content.file_url;
     default:
       return content.url_preview;

--- a/src/application/utils/helper.ts
+++ b/src/application/utils/helper.ts
@@ -3,8 +3,9 @@ export const getSrcByType = (content: Scrap | Category) => {
     case 'link':
       return content.url_preview;
     case 'image':
-    default:
       return content.file_url;
+    default:
+      return content.url_preview;
   }
 };
 

--- a/src/components/scrap/Content/PdfViewer.tsx
+++ b/src/components/scrap/Content/PdfViewer.tsx
@@ -1,0 +1,34 @@
+import 'react-pdf/dist/esm/Page/TextLayer.css';
+
+import { useState } from 'react';
+import { Document, Page, pdfjs } from 'react-pdf';
+
+import useWindowSize from '@/application/hooks/common/useWindowSize';
+pdfjs.GlobalWorkerOptions.workerSrc = `//unpkg.com/pdfjs-dist@${pdfjs.version}/build/pdf.worker.min.js`;
+
+interface Props {
+  src: string;
+  onClick?: () => void;
+}
+export const PdfViewer = ({ src, onClick }: Props) => {
+  const [numPages, setNumPages] = useState(0);
+  const windowSize = useWindowSize();
+
+  const handleDocumentLoadSuccess = ({ numPages }: { numPages: number }) => {
+    setNumPages(numPages);
+  };
+  return (
+    <Document file={src} onLoadSuccess={handleDocumentLoadSuccess}>
+      {Array.from(new Array(numPages), (_, index) => (
+        <Page
+          width={windowSize.width}
+          height={windowSize.height}
+          key={index}
+          pageNumber={index + 1}
+          renderAnnotationLayer={false}
+          onClick={onClick}
+        />
+      ))}
+    </Document>
+  );
+};

--- a/src/components/scrap/Content/SwipeBackground.tsx
+++ b/src/components/scrap/Content/SwipeBackground.tsx
@@ -1,14 +1,16 @@
 import { css } from '@emotion/react';
+import dynamic from 'next/dynamic';
 import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
+const PdfViewer = dynamic(() => import('./PdfViewer').then((m) => m.PdfViewer));
 
 type SwipeBackgroundProps = (
   | { type: 'image'; src?: string }
   | { type: 'text'; text?: string }
   | { type: 'link'; src?: string; href: string }
-  | { type: 'video'; src?: string; href: string }
-  | { type: 'pdf'; src?: string; href: string }
+  | { type: 'video'; src?: string }
+  | { type: 'pdf'; src?: string }
 ) & { onClick?: () => void; isFull?: boolean };
 
 const SwipeBackground = (props: SwipeBackgroundProps) => {
@@ -16,7 +18,6 @@ const SwipeBackground = (props: SwipeBackgroundProps) => {
     <div
       css={[
         css`
-          user-select: none;
           position: fixed;
           left: 0;
           top: 0;
@@ -24,6 +25,7 @@ const SwipeBackground = (props: SwipeBackgroundProps) => {
           height: 58vh;
           max-width: 440px;
           margin: auto;
+          overflow-y: auto;
         `,
         (theme) =>
           props.isFull &&
@@ -66,7 +68,23 @@ const SwipeBackground = (props: SwipeBackgroundProps) => {
             <Image priority src={props.src || '/icon/scrap/defaultCategory.svg'} layout="fill" objectFit={'cover'} />
           </a>
         </Link>
-      ) : props.type === 'video' ? null : props.type === 'pdf' ? null : null}
+      ) : props.type === 'video' ? (
+        <video
+          autoPlay
+          loop
+          onClick={props.onClick}
+          css={css`
+            max-width: 100%;
+            transform: translateY(-50%);
+            position: relative;
+            top: 50%;
+          `}
+        >
+          <source src={props.src} />
+        </video>
+      ) : props.type === 'pdf' && props.src ? (
+        <PdfViewer src={props.src} onClick={props.onClick} />
+      ) : null}
     </div>
   );
 };

--- a/src/components/scrap/Content/SwipeBackground.tsx
+++ b/src/components/scrap/Content/SwipeBackground.tsx
@@ -60,13 +60,13 @@ const SwipeBackground = (props: SwipeBackgroundProps) => {
         >
           {props.text}
         </span>
-      ) : (
+      ) : props.type === 'link' ? (
         <Link href={props.href}>
           <a rel="noopener noreferrer" target="_blank">
             <Image priority src={props.src || '/icon/scrap/defaultCategory.svg'} layout="fill" objectFit={'cover'} />
           </a>
         </Link>
-      )}
+      ) : props.type === 'video' ? null : props.type === 'pdf' ? null : null}
     </div>
   );
 };

--- a/src/components/scrap/Content/SwipeBackground.tsx
+++ b/src/components/scrap/Content/SwipeBackground.tsx
@@ -3,28 +3,47 @@ import Image from 'next/image';
 import Link from 'next/link';
 import React from 'react';
 
-type SwipeBackgroundProps =
+type SwipeBackgroundProps = (
   | { type: 'image'; src?: string }
   | { type: 'text'; text?: string }
-  | { type: 'link'; src?: string; href: string };
+  | { type: 'link'; src?: string; href: string }
+  | { type: 'video'; src?: string; href: string }
+  | { type: 'pdf'; src?: string; href: string }
+) & { onClick?: () => void; isFull?: boolean };
 
 const SwipeBackground = (props: SwipeBackgroundProps) => {
   return (
     <div
-      css={css`
-        position: fixed;
-        left: 0;
-        top: 0;
-        right: 0;
-        height: 58vh;
-        max-width: 440px;
-        margin: auto;
-      `}
+      css={[
+        css`
+          user-select: none;
+          position: fixed;
+          left: 0;
+          top: 0;
+          right: 0;
+          height: 58vh;
+          max-width: 440px;
+          margin: auto;
+        `,
+        (theme) =>
+          props.isFull &&
+          css`
+            height: 100vh;
+            background-color: ${theme.color.black02};
+          `,
+      ]}
     >
       {props.type === 'image' ? (
-        <Image priority src={props.src || '/icon/scrap/defaultCategory.svg'} layout="fill" objectFit={'cover'} />
+        <Image
+          onClick={props.onClick}
+          priority
+          src={props.src || '/icon/scrap/defaultCategory.svg'}
+          layout="fill"
+          objectFit={props.isFull ? 'contain' : 'cover'}
+        />
       ) : props.type === 'text' ? (
         <span
+          onClick={props.onClick}
           css={(theme) => css`
             background: ${theme.color.gray02};
             word-wrap: break-word;

--- a/src/components/scrap/Content/SwipeSection.tsx
+++ b/src/components/scrap/Content/SwipeSection.tsx
@@ -1,6 +1,6 @@
 import { css } from '@emotion/react';
 import type { PropsWithChildren, ReactElement } from 'react';
-import React, { createContext, useContext, useEffect, useState } from 'react';
+import React, { cloneElement, createContext, useContext, useEffect, useState } from 'react';
 import { useSwipeable } from 'react-swipeable';
 
 import Chip from '@/components/common/Chip';
@@ -11,11 +11,16 @@ const OPEN_DELAY = 400;
 
 function SwipeSectionRoot({ children, background }: PropsWithChildren<{ background?: ReactElement }>) {
   const [open, setOpen] = useState(false);
+  const [isFull, setIsFull] = useState(false);
 
   const handlers = useSwipeable({
     onSwipedUp: () => setOpen(true),
     onSwipedDown: () => setOpen(false),
   });
+
+  const handleBackgroundClick = () => {
+    setIsFull((prev) => !prev);
+  };
 
   /**
    * @todo (refactor)
@@ -23,32 +28,34 @@ function SwipeSectionRoot({ children, background }: PropsWithChildren<{ backgrou
    */
   return (
     <SwipeSectionContext.Provider value={open}>
-      {background}
-      <section
-        {...handlers}
-        css={css`
-          position: fixed;
-          bottom: 0;
-          left: 0;
-          right: 0;
-          width: 100%;
-          max-width: 440px; // TODO max width constant
-          margin: auto;
-          max-height: ${open ? '90vh' : '44vh'};
-          height: 100%;
-          background: #ffffff;
-          box-shadow: 0 1px 20px rgba(0, 0, 0, 0.1);
-          border-radius: 10px 10px 0 0;
-          padding: 10px 16px;
-          display: flex;
-          flex-direction: column;
-          align-items: flex-start;
-          justify-content: space-between;
-          transition: max-height ${OPEN_DELAY}ms ease-in-out;
-        `}
-      >
-        {children}
-      </section>
+      {background && cloneElement(background, { isFull, onClick: handleBackgroundClick })}
+      {!isFull ? (
+        <section
+          {...handlers}
+          css={css`
+            position: fixed;
+            bottom: 0;
+            left: 0;
+            right: 0;
+            width: 100%;
+            max-width: 440px; // TODO max width constant
+            margin: auto;
+            max-height: ${open ? '90vh' : '44vh'};
+            height: 100%;
+            background: #ffffff;
+            box-shadow: 0 1px 20px rgba(0, 0, 0, 0.1);
+            border-radius: 10px 10px 0 0;
+            padding: 10px 16px;
+            display: flex;
+            flex-direction: column;
+            align-items: flex-start;
+            justify-content: space-between;
+            transition: max-height ${OPEN_DELAY}ms ease-in-out;
+          `}
+        >
+          {children}
+        </section>
+      ) : null}
     </SwipeSectionContext.Provider>
   );
 }

--- a/src/components/scrap/Content/SwipeSection.tsx
+++ b/src/components/scrap/Content/SwipeSection.tsx
@@ -22,10 +22,6 @@ function SwipeSectionRoot({ children, background }: PropsWithChildren<{ backgrou
     setIsFull((prev) => !prev);
   };
 
-  /**
-   * @todo (refactor)
-   *   Background 컴포넌트 props로 받지 말고 children 에서 get 하기
-   */
   return (
     <SwipeSectionContext.Provider value={open}>
       {background && cloneElement(background, { isFull, onClick: handleBackgroundClick })}
@@ -35,22 +31,18 @@ function SwipeSectionRoot({ children, background }: PropsWithChildren<{ backgrou
           css={css`
             position: fixed;
             bottom: 0;
-            left: 0;
-            right: 0;
+            transform: translateX(-16px);
             width: 100%;
-            max-width: 440px; // TODO max width constant
-            margin: auto;
-            max-height: ${open ? '90vh' : '44vh'};
-            height: 100%;
+            max-width: 440px;
+            min-height: ${open ? '90vh' : '44vh'};
             background: #ffffff;
             box-shadow: 0 1px 20px rgba(0, 0, 0, 0.1);
             border-radius: 10px 10px 0 0;
             padding: 10px 16px;
             display: flex;
             flex-direction: column;
-            align-items: flex-start;
             justify-content: space-between;
-            transition: max-height ${OPEN_DELAY}ms ease-in-out;
+            transition: min-height ${OPEN_DELAY}ms ease-in-out;
           `}
         >
           {children}

--- a/src/components/scrap/Toast/CreateScrap.tsx
+++ b/src/components/scrap/Toast/CreateScrap.tsx
@@ -9,7 +9,7 @@ import useModal from '@/application/hooks/common/useModal';
 import usePopup from '@/application/hooks/common/usePopup';
 import useToast from '@/application/hooks/common/useToast';
 import useScrapForm from '@/application/store/scrap/useScrapForm';
-import { ERR_CODE } from '@/application/utils/constant';
+import { ERR_CODE, ERR_MESSAGE } from '@/application/utils/constant';
 import CreateCategory from '@/components/category/Modal/CreateCategory';
 import SelectCategoryWithCreate from '@/components/category/Select/SelectCategoryWithCreate';
 import { ActiveButton } from '@/components/common/Button';
@@ -32,7 +32,14 @@ const CreateScrap = () => {
     const file = e.target.files?.[0];
     if (!file) return;
 
-    handleScrap({ type: 'file', data: file });
+    const type = file.name.split('.').pop();
+    if (!type) throw Error(ERR_MESSAGE.NOT_SUPPORTED_FILE);
+
+    if (/(png|jpg|jpeg)/.test(type)) handleScrap({ type: 'image', data: file });
+    else if (/pdf/.test(type)) handleScrap({ type: 'pdf', data: file });
+    else if (/mp4/.test(type)) handleScrap({ type: 'video', data: file });
+    else throw Error(ERR_MESSAGE.NOT_SUPPORTED_FILE);
+
     replace({ content: <SelectCategoryWithCreate /> });
   };
   const handleLinkInput = () => replace({ content: <TypedDetailToast type={'link'} /> });

--- a/src/pages/scrap/[id].tsx
+++ b/src/pages/scrap/[id].tsx
@@ -27,14 +27,14 @@ const ShowScrap: NextPage = () => {
     setRequest(mutation.mutate);
   }, [mutation.mutate, setRequest]);
 
-  const scrapType = scrap?.scrap_type as 'image' | 'text' | 'link';
+  const scrapType = scrap?.scrap_type as Scrap['scrap_type'];
 
   const swipeBackgroundProps =
     scrapType === 'text'
       ? { text: scrap?.content, type: scrapType }
-      : scrapType === 'image'
-      ? { src: scrap?.file_url, type: scrapType }
-      : { src: scrap?.url_preview, type: scrapType, href: scrap?.content || '' };
+      : scrapType === 'link'
+      ? { src: scrap?.url_preview, type: scrapType, href: scrap?.content || '' }
+      : { src: scrap?.file_url, type: scrapType };
 
   return (
     <>

--- a/yarn.lock
+++ b/yarn.lock
@@ -3127,6 +3127,14 @@
   dependencies:
     "@types/react" "*"
 
+"@types/react-pdf@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@types/react-pdf/-/react-pdf-6.2.0.tgz#e99d498f8f76704d15e4553197c89e254cc17278"
+  integrity sha512-OSCYmrfaJvpXkM5V4seUMAhUDOAOqbGQf9kwv14INyTf7AjDs2ukfkkQrLWRQ8OjWrDklbXYWh5l7pT7l0N76g==
+  dependencies:
+    "@types/react" "*"
+    pdfjs-dist "^2.16.105"
+
 "@types/react@*", "@types/react@18.0.22":
   version "18.0.22"
   resolved "https://registry.npmjs.org/@types/react/-/react-18.0.22.tgz"
@@ -4714,7 +4722,7 @@ clsx@1.1.0:
   resolved "https://registry.npmjs.org/clsx/-/clsx-1.1.0.tgz"
   integrity sha512-3avwM37fSK5oP6M5rQ9CNe99lwxhXDOeSWVPAOYF6OazUTgZCMb0yWlJpmdD74REy1gkEaFiub2ULv4fq9GUhA==
 
-clsx@^1.0.4:
+clsx@^1.0.4, clsx@^1.2.1:
   version "1.2.1"
   resolved "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz"
   integrity sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==
@@ -5403,6 +5411,11 @@ domhandler@^4.0.0, domhandler@^4.2.0, domhandler@^4.3.1:
   integrity sha512-GrwoxYN+uWlzO8uhUXRl0P+kHE4GtVPfYzVLcUxPL7KNdHKj66vvlhiweIHqYYXWlw+T8iLMp42Lm67ghw4WMQ==
   dependencies:
     domelementtype "^2.2.0"
+
+dommatrix@^1.0.3:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/dommatrix/-/dommatrix-1.0.3.tgz#e7c18e8d6f3abdd1fef3dd4aa74c4d2e620a0525"
+  integrity sha512-l32Xp/TLgWb8ReqbVJAFIvXmY7go4nTxxlWiAFyhoQw9RKEOHBZNnyGvJWqDVSPmq3Y9HlM4npqF/T6VMOXhww==
 
 domutils@^2.5.2, domutils@^2.8.0:
   version "2.8.0"
@@ -8023,6 +8036,11 @@ lz-string@^1.4.4:
   resolved "https://registry.npmjs.org/lz-string/-/lz-string-1.4.4.tgz"
   integrity sha512-0ckx7ZHRPqb0oUm8zNr+90mtf9DQB60H1wMCjBtfi62Kl3a7JbHob6gA2bC+xRvZoOL+1hzUK8jeuEIQE8svEQ==
 
+make-cancellable-promise@^1.0.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/make-cancellable-promise/-/make-cancellable-promise-1.2.0.tgz#a71ce4d000e9f3b26dab95dcc39947506440e792"
+  integrity sha512-sLhwwkWNAtPpvYh1Yen8QRMm6tRReFsheUri2muqIrZEDwEHBPAsQeAD5ezZ4F7wjdmttoZL+w/BDkgmvOQSsA==
+
 make-dir@^2.0.0, make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz"
@@ -8037,6 +8055,11 @@ make-dir@^3.0.0, make-dir@^3.0.2, make-dir@^3.1.0:
   integrity sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
   dependencies:
     semver "^6.0.0"
+
+make-event-props@^1.1.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/make-event-props/-/make-event-props-1.3.0.tgz#2434cb390d58bcf40898d009ef5b1f936de9671b"
+  integrity sha512-oWiDZMcVB1/A487251hEWza1xzgCzl6MXxe9aF24l5Bt9N9UEbqTqKumEfuuLhmlhRZYnc+suVvW4vUs8bwO7Q==
 
 makeerror@1.0.12:
   version "1.0.12"
@@ -8194,6 +8217,13 @@ merge-descriptors@1.0.1:
   version "1.0.1"
   resolved "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
   integrity sha512-cCi6g3/Zr1iqQi6ySbseM1Xvooa98N0w31jzUYrXPX2xqObmFGHJ0tQ5u74H3mVh7wLouTseZyYIq39g8cNp1w==
+
+merge-refs@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/merge-refs/-/merge-refs-1.1.0.tgz#31cbfa18264184cbea8c9e1dcc0b117ff30a65a4"
+  integrity sha512-5f0EKS2NOmk+SGtt9jsd7Bdloe+c7//PIf2qnFBx37FoxLrKJHLMvgnfZhbkYzLtXRUTj8H6FZfvbkoYhz5rLw==
+  dependencies:
+    "@types/react" "*"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -9083,6 +9113,14 @@ pbkdf2@^3.0.3:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
+pdfjs-dist@2.16.105, pdfjs-dist@^2.16.105:
+  version "2.16.105"
+  resolved "https://registry.yarnpkg.com/pdfjs-dist/-/pdfjs-dist-2.16.105.tgz#937b9c4a918f03f3979c88209d84c1ce90122c2a"
+  integrity sha512-J4dn41spsAwUxCpEoVf6GVoz908IAA3mYiLmNxg8J9kfRXc2jxpbUepcP0ocp0alVNLFthTAM8DZ1RaHh8sU0A==
+  dependencies:
+    dommatrix "^1.0.3"
+    web-streams-polyfill "^3.2.1"
+
 picocolors@^0.2.1:
   version "0.2.1"
   resolved "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz"
@@ -9408,7 +9446,7 @@ prompts@^2.4.0:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@^15.0.0, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@^15.0.0, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -9641,6 +9679,21 @@ react-merge-refs@^1.0.0:
   version "1.1.0"
   resolved "https://registry.npmjs.org/react-merge-refs/-/react-merge-refs-1.1.0.tgz"
   integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
+
+react-pdf@^6.2.2:
+  version "6.2.2"
+  resolved "https://registry.yarnpkg.com/react-pdf/-/react-pdf-6.2.2.tgz#61dbf1cd32b49bb452c8dd26e7ee7b2f987e4904"
+  integrity sha512-huNWhzzTAb3t1mWA6WOR9yQRCbcZ6uXCGC46cEAgEhGqvXTB6RcHm+1DS2r9OdPNUZ9SZTuR6jZ1BNOJIiEing==
+  dependencies:
+    "@babel/runtime" "^7.0.0"
+    clsx "^1.2.1"
+    make-cancellable-promise "^1.0.0"
+    make-event-props "^1.1.0"
+    merge-refs "^1.0.0"
+    pdfjs-dist "2.16.105"
+    prop-types "^15.6.2"
+    tiny-invariant "^1.0.0"
+    tiny-warning "^1.0.0"
 
 react-refresh@^0.11.0:
   version "0.11.0"
@@ -10961,6 +11014,16 @@ tiny-glob@^0.2.9:
     globalyzer "0.1.0"
     globrex "^0.1.2"
 
+tiny-invariant@^1.0.0:
+  version "1.3.1"
+  resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.1.tgz#8560808c916ef02ecfd55e66090df23a4b7aa642"
+  integrity sha512-AD5ih2NlSssTCwsMznbvwMZpJ1cbhkGd2uueNxzv2jDlEeZdU04JQfRnggJQ8DrcVBGjAsCKwFBbDlVNtEMlzw==
+
+tiny-warning@^1.0.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/tiny-warning/-/tiny-warning-1.0.3.tgz#94a30db453df4c643d0fd566060d60a875d84754"
+  integrity sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA==
+
 tmpl@1.0.5:
   version "1.0.5"
   resolved "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz"
@@ -11518,6 +11581,11 @@ web-namespaces@^1.0.0:
   version "1.1.4"
   resolved "https://registry.npmjs.org/web-namespaces/-/web-namespaces-1.1.4.tgz"
   integrity sha512-wYxSGajtmoP4WxfejAPIr4l0fVh+jeMXZb08wNc0tMg6xsfZXj3cECqIK0G7ZAqUq0PP8WlMDtaOGVBTAWztNw==
+
+web-streams-polyfill@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/web-streams-polyfill/-/web-streams-polyfill-3.2.1.tgz#71c2718c52b45fd49dbeee88634b3a60ceab42a6"
+  integrity sha512-e0MO3wdXWKrLbL0DgGnUV7WHVuw9OUvL4hjgnPkIeEvESk74gAITi5G606JtZPp39cd8HA9VQzCIvA49LpPN5Q==
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
## 📮 관련 이슈
- Resolved: #이슈번호

## ⛳️ 작업 내용

### 1. 스크랩 콘텐츠 배경화면 클릭 시 전체화면
- 이미지/비디오 타입의 경우 남는 여백 `center`로 정렬
- 링크 타입은 해당되지 않음
- 텍스트/PDF 타입은 따로 정렬하지 않음
- 전체화면 여부를 판별하기 위해 `const [isFull, ...] = useState(false)` 작성

### 2. 비디오 콘텐츠 렌더링
- `<video />` 태그 활용
- autoPlay, loop로 자동 재생 및 무한 반복

### 3. PDF 콘텐츠 렌더링
- `react-pdf` 라이브러리 활용
- `height`,  `width`를 number 타입으로 설정하기 위해 (라이브러리 요구사항) `useWindowSize` hook 작성

### 4. 스크랩 업로드 타입 수정
- pdf/비디오 타입도 `scrap_type=image`로 api 요청하는 현상 수정

## 🌱 PR 포인트
-

## 📸 스크린샷
|스크린샷| - | 
|:--:|:--:|
|![Jan-16-2023 02-18-04](https://user-images.githubusercontent.com/74011724/212556384-09e1582a-efeb-4e47-9561-93bd4da5260f.gif)|![Jan-16-2023 02-17-37](https://user-images.githubusercontent.com/74011724/212556389-5e970661-8fe1-4cd5-9818-0125b0ee7ddd.gif)|
## 📎 레퍼런스
- `react-pdf` : https://kyounghwan01.github.io/blog/React/next/pdf-viewer/
<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->