### PR TITLE
Design/Feat: 재방문 콘텐츠 UI/API 연결

### DIFF
--- a/src/application/hooks/api/analysis/index.ts
+++ b/src/application/hooks/api/analysis/index.ts
@@ -17,3 +17,11 @@ export const useGetTagAnalysisForYearMonth = (year: number, month: number) => {
   });
   return { detailAnalysis: data?.data.data || [], ...rest };
 };
+
+export const useGetRevisitAnalysis = () => {
+  const { data, ...rest } = useQuery({
+    queryKey: ['getRevisitAnalysis'],
+    queryFn: api.analysis.getRevisitAnalysis,
+  });
+  return { revisitAnalysis: data?.data.data || [], ...rest };
+};

--- a/src/application/utils/helper.ts
+++ b/src/application/utils/helper.ts
@@ -1,14 +1,14 @@
-export const getSrcByType = (content: Scrap | Category) => {
+export const getSrcByType = (content: Scrap | Category | RevisitAnalysis) => {
   if (content.scrap_type === null) return '';
   switch (content.scrap_type.toLowerCase()) {
     case 'link':
-      return content.url_preview;
+      return content.preview_url;
     case 'image':
     case 'video':
     case 'pdf':
       return content.file_url;
     default:
-      return content.url_preview;
+      return content.preview_url;
   }
 };
 

--- a/src/components/analysis/Revisit/NoRevisit/index.tsx
+++ b/src/components/analysis/Revisit/NoRevisit/index.tsx
@@ -1,0 +1,34 @@
+import { css } from '@emotion/react';
+import Image from 'next/image';
+
+const NoRevisit = () => {
+  return (
+    <div
+      css={(theme) => css`
+        display: flex;
+        padding-top: 2vh;
+        flex-direction: column;
+        flex: 1;
+        justify-content: center;
+        align-items: center;
+        gap: 20px;
+        ${theme.font.M_POINT_14};
+        color: ${theme.color.gray06};
+      `}
+    >
+      <span
+        css={css`
+          position: relative;
+          transform: translateX(-4px);
+          height: 10vh;
+          width: 155px;
+        `}
+      >
+        <Image src={'/picture/warn.svg'} layout="fill" objectFit={'contain'} />
+      </span>
+      <span>모든 콘텐츠를 방문하였습니다.</span>
+    </div>
+  );
+};
+
+export default NoRevisit;

--- a/src/components/analysis/Revisit/RevisitPhoto.tsx
+++ b/src/components/analysis/Revisit/RevisitPhoto.tsx
@@ -1,0 +1,5 @@
+const RevisitPhoto = () => {
+  return <h1>재방문 콘텐츠 아이템</h1>;
+};
+
+export default RevisitPhoto;

--- a/src/components/analysis/Revisit/RevisitPhoto.tsx
+++ b/src/components/analysis/Revisit/RevisitPhoto.tsx
@@ -1,5 +1,0 @@
-const RevisitPhoto = () => {
-  return <h1>재방문 콘텐츠 아이템</h1>;
-};
-
-export default RevisitPhoto;

--- a/src/components/analysis/Revisit/RevisitPhotoList.tsx
+++ b/src/components/analysis/Revisit/RevisitPhotoList.tsx
@@ -36,6 +36,7 @@ const RevisitPhotoList = ({ thumId, thum, title }: RevisitPhotoListProps) => {
         css={(theme) => css`
           color: ${theme.color.black03};
           ${theme.font.R_BODY_13};
+          margin: 6px 0;
         `}
       >
         {title}

--- a/src/components/analysis/Revisit/RevisitPhotoList.tsx
+++ b/src/components/analysis/Revisit/RevisitPhotoList.tsx
@@ -1,5 +1,47 @@
-const RevisitPhotoList = () => {
-  return <h1>재방문 스크랩 아이템들 나열할 컴포넌트</h1>;
+import { css } from '@emotion/react';
+import { useRouter } from 'next/router';
+
+import { getSrcByType } from '@/application/utils/helper';
+import Photo from '@/components/common/Photo';
+
+interface RevisitPhotoListProps {
+  thumId: number;
+  thum: RevisitAnalysis;
+  title?: string;
+  onClick?: () => void;
+}
+
+const RevisitPhotoList = ({ thumId, thum, title }: RevisitPhotoListProps) => {
+  const router = useRouter();
+
+  const handleClickPhoto = (thumId: number) => {
+    router.push(`/scrap/${thumId}`);
+  };
+
+  return (
+    <div
+      css={css`
+        display: flex;
+        flex-direction: column;
+      `}
+      onClick={() => handleClickPhoto(thumId)}
+    >
+      <Photo
+        custom={css`
+          aspect-ratio: 1/1;
+        `}
+        src={getSrcByType(thum)}
+      />
+      <div
+        css={(theme) => css`
+          color: ${theme.color.black03};
+          ${theme.font.R_BODY_13};
+        `}
+      >
+        {title}
+      </div>
+    </div>
+  );
 };
 
 export default RevisitPhotoList;

--- a/src/components/analysis/Revisit/RevisitPhotoList.tsx
+++ b/src/components/analysis/Revisit/RevisitPhotoList.tsx
@@ -1,0 +1,5 @@
+const RevisitPhotoList = () => {
+  return <h1>재방문 스크랩 아이템들 나열할 컴포넌트</h1>;
+};
+
+export default RevisitPhotoList;

--- a/src/components/analysis/Revisit/RevisitTitle.tsx
+++ b/src/components/analysis/Revisit/RevisitTitle.tsx
@@ -14,11 +14,7 @@ const RevisitTitle = ({ active }: RevisitTitleProps) => {
       `}
     >
       <div css={CSSYellowBall(active)} />
-      {active ? (
-        <p css={CSSRevisitTitleDetailBold}>&lsquo;방문하지 않은&rsquo;</p>
-      ) : (
-        <p css={CSSRevisitTitleBold}>&lsquo;방문하지 않은&rsquo;</p>
-      )}
+      <p css={CSSRevisitTitleDetail(active)}>&lsquo;방문하지 않은&rsquo;</p>
       <p css={CSSRevisitTitle(active)}>콘텐츠가 있어요</p>
     </div>
   );
@@ -35,20 +31,13 @@ const CSSYellowBall = (active: boolean) =>
     height: ${active ? '19px' : '12px'};
   `;
 
-const CSSRevisitTitleBold = (theme: Theme) =>
+const CSSRevisitTitleDetail = (active: boolean) => (theme: Theme) =>
   css`
     position: relative;
     color: ${theme.color.black01};
     margin: 0 10px 0 5px;
-    ${theme.font.B_POINT_18};
+    ${active ? theme.font.B_POINT_22 : theme.font.B_POINT_18};
   `;
-
-const CSSRevisitTitleDetailBold = (theme: Theme) => css`
-  position: relative;
-  color: ${theme.color.black01};
-  margin: 0 10px 0 5px;
-  ${theme.font.B_POINT_22};
-`;
 
 const CSSRevisitTitle = (active: boolean) => (theme: Theme) =>
   css`

--- a/src/components/analysis/Revisit/RevisitTitle.tsx
+++ b/src/components/analysis/Revisit/RevisitTitle.tsx
@@ -1,0 +1,60 @@
+import type { Theme } from '@emotion/react';
+import { css } from '@emotion/react';
+
+interface RevisitTitleProps {
+  active: boolean;
+}
+
+const RevisitTitle = ({ active }: RevisitTitleProps) => {
+  return (
+    <div
+      css={css`
+        position: relative;
+        display: flex;
+      `}
+    >
+      <div css={CSSYellowBall(active)} />
+      {active ? (
+        <p css={CSSRevisitTitleDetailBold}>&lsquo;방문하지 않은&rsquo;</p>
+      ) : (
+        <p css={CSSRevisitTitleBold}>&lsquo;방문하지 않은&rsquo;</p>
+      )}
+      <p css={CSSRevisitTitle(active)}>콘텐츠가 있어요</p>
+    </div>
+  );
+};
+
+const CSSYellowBall = (active: boolean) =>
+  css`
+    position: absolute;
+    border-radius: 100%;
+    background-color: #f6d936;
+    z-index: 0;
+    bottom: 11px;
+    width: ${active ? '19px' : '12px'};
+    height: ${active ? '19px' : '12px'};
+  `;
+
+const CSSRevisitTitleBold = (theme: Theme) =>
+  css`
+    position: relative;
+    color: ${theme.color.black01};
+    margin: 0 10px 0 5px;
+    ${theme.font.B_POINT_18};
+  `;
+
+const CSSRevisitTitleDetailBold = (theme: Theme) => css`
+  position: relative;
+  color: ${theme.color.black01};
+  margin: 0 10px 0 5px;
+  ${theme.font.B_POINT_22};
+`;
+
+const CSSRevisitTitle = (active: boolean) => (theme: Theme) =>
+  css`
+    ${theme.font.M_POINT_16};
+    color: ${theme.color.gray03};
+    margin-top: ${active ? '6px' : '2px'};
+  `;
+
+export default RevisitTitle;

--- a/src/components/analysis/RevisitContent.tsx
+++ b/src/components/analysis/RevisitContent.tsx
@@ -1,14 +1,17 @@
 import { css } from '@emotion/react';
+import { useRouter } from 'next/router';
 import { useRecoilState } from 'recoil';
 
 import { useGetRevisitAnalysis } from '@/application/hooks/api/analysis';
 import { revisitDetailState } from '@/application/store/analysis/analysisState';
+import { getSrcByType } from '@/application/utils/helper';
 
 import Photo from '../common/Photo';
 import SubAnaNavigation from './AnaNavigation/SubAnaNavigation';
 import RevisitTitle from './Revisit/RevisitTitle';
 
 const RevisitContent = () => {
+  const router = useRouter();
   const [revisitState, setRevisitState] = useRecoilState(revisitDetailState);
   const { revisitAnalysis } = useGetRevisitAnalysis();
   const revisitContentThum = revisitAnalysis.slice(0, 2);
@@ -16,6 +19,10 @@ const RevisitContent = () => {
 
   const handleClickMoreBtn = () => {
     setRevisitState(!revisitState);
+  };
+
+  const handleClickPhoto = (thumId: number) => {
+    router.push(`/scrap/${thumId}`);
   };
 
   return (
@@ -41,6 +48,8 @@ const RevisitContent = () => {
               custom={css`
                 aspect-ratio: 1/1;
               `}
+              onClick={() => handleClickPhoto(thum.scrap_id)}
+              src={getSrcByType(thum)}
             />
           ))}
         </div>

--- a/src/components/analysis/RevisitContent.tsx
+++ b/src/components/analysis/RevisitContent.tsx
@@ -4,13 +4,15 @@ import { useRecoilState } from 'recoil';
 import { useGetRevisitAnalysis } from '@/application/hooks/api/analysis';
 import { revisitDetailState } from '@/application/store/analysis/analysisState';
 
+import Photo from '../common/Photo';
 import SubAnaNavigation from './AnaNavigation/SubAnaNavigation';
 import RevisitTitle from './Revisit/RevisitTitle';
 
 const RevisitContent = () => {
   const [revisitState, setRevisitState] = useRecoilState(revisitDetailState);
   const { revisitAnalysis } = useGetRevisitAnalysis();
-  console.log(revisitAnalysis);
+  const revisitContentThum = revisitAnalysis.slice(0, 2);
+  console.log(revisitContentThum);
 
   const handleClickMoreBtn = () => {
     setRevisitState(!revisitState);
@@ -27,20 +29,31 @@ const RevisitContent = () => {
       </SubAnaNavigation>
       <div
         css={css`
-          height: 315px;
+          height: 100%;
+          padding: 12px 0 32px;
         `}
       >
-        <div
-          css={css`
-            height: 100%;
-            padding: 12px 0 32px;
-          `}
-        >
-          <RevisitTitle active={false} />
+        <RevisitTitle active={false} />
+        <div css={CSSPhotoListContainer}>
+          {revisitContentThum.map((thum) => (
+            <Photo
+              key={thum.scrap_id}
+              custom={css`
+                aspect-ratio: 1/1;
+              `}
+            />
+          ))}
         </div>
       </div>
     </div>
   );
 };
+
+const CSSPhotoListContainer = css`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(60px, 1fr));
+  gap: 9px;
+  margin-top: 24px;
+`;
 
 export default RevisitContent;

--- a/src/components/analysis/RevisitContent.tsx
+++ b/src/components/analysis/RevisitContent.tsx
@@ -5,17 +5,16 @@ import { useRecoilState } from 'recoil';
 import { useGetRevisitAnalysis } from '@/application/hooks/api/analysis';
 import { revisitDetailState } from '@/application/store/analysis/analysisState';
 import { getSrcByType } from '@/application/utils/helper';
-
-import Photo from '../common/Photo';
-import SubAnaNavigation from './AnaNavigation/SubAnaNavigation';
-import RevisitTitle from './Revisit/RevisitTitle';
+import SubAnaNavigation from '@/components/analysis/AnaNavigation/SubAnaNavigation';
+import NoRevisit from '@/components/analysis/Revisit/NoRevisit';
+import RevisitTitle from '@/components/analysis/Revisit/RevisitTitle';
+import Photo from '@/components/common/Photo';
 
 const RevisitContent = () => {
   const router = useRouter();
   const [revisitState, setRevisitState] = useRecoilState(revisitDetailState);
   const { revisitAnalysis } = useGetRevisitAnalysis();
   const revisitContentThum = revisitAnalysis.slice(0, 2);
-  console.log(revisitContentThum);
 
   const handleClickMoreBtn = () => {
     setRevisitState(!revisitState);
@@ -40,19 +39,25 @@ const RevisitContent = () => {
           padding: 12px 0 32px;
         `}
       >
-        <RevisitTitle active={false} />
-        <div css={CSSPhotoListContainer}>
-          {revisitContentThum.map((thum) => (
-            <Photo
-              key={thum.scrap_id}
-              custom={css`
-                aspect-ratio: 1/1;
-              `}
-              onClick={() => handleClickPhoto(thum.scrap_id)}
-              src={getSrcByType(thum)}
-            />
-          ))}
-        </div>
+        {revisitAnalysis.length === 0 ? (
+          <NoRevisit />
+        ) : (
+          <>
+            <RevisitTitle active={false} />
+            <div css={CSSPhotoListContainer}>
+              {revisitContentThum.map((thum) => (
+                <Photo
+                  key={thum.scrap_id}
+                  custom={css`
+                    aspect-ratio: 1/1;
+                  `}
+                  onClick={() => handleClickPhoto(thum.scrap_id)}
+                  src={getSrcByType(thum)}
+                />
+              ))}
+            </div>
+          </>
+        )}
       </div>
     </div>
   );

--- a/src/components/analysis/RevisitContent.tsx
+++ b/src/components/analysis/RevisitContent.tsx
@@ -1,12 +1,16 @@
 import { css } from '@emotion/react';
 import { useRecoilState } from 'recoil';
 
+import { useGetRevisitAnalysis } from '@/application/hooks/api/analysis';
 import { revisitDetailState } from '@/application/store/analysis/analysisState';
 
 import SubAnaNavigation from './AnaNavigation/SubAnaNavigation';
+import RevisitTitle from './Revisit/RevisitTitle';
 
 const RevisitContent = () => {
   const [revisitState, setRevisitState] = useRecoilState(revisitDetailState);
+  const { revisitAnalysis } = useGetRevisitAnalysis();
+  console.log(revisitAnalysis);
 
   const handleClickMoreBtn = () => {
     setRevisitState(!revisitState);
@@ -32,7 +36,7 @@ const RevisitContent = () => {
             padding: 12px 0 32px;
           `}
         >
-          재방문 콘텐츠
+          <RevisitTitle active={false} />
         </div>
       </div>
     </div>

--- a/src/components/common/Photo/index.tsx
+++ b/src/components/common/Photo/index.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import type { ReactElement } from 'react';
 
 interface PhotoProps {
-  src: string;
+  src?: string;
   width?: string;
   height?: string;
   blur?: ReactElement;

--- a/src/components/common/Photo/index.tsx
+++ b/src/components/common/Photo/index.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import type { ReactElement } from 'react';
 
 interface PhotoProps {
-  src?: string;
+  src: string | null | undefined;
   width?: string;
   height?: string;
   blur?: ReactElement;

--- a/src/containers/analysis/RevisitAnalysis/RevisitAnalysisDetail.tsx
+++ b/src/containers/analysis/RevisitAnalysis/RevisitAnalysisDetail.tsx
@@ -7,28 +7,46 @@ import RevisitTitle from '@/components/analysis/Revisit/RevisitTitle';
 
 const RevisitAnalysisDetail = () => {
   const { revisitAnalysis } = useGetRevisitAnalysis();
-  console.log(revisitAnalysis);
 
   return (
     <>
       <div
         css={css`
           height: 100%;
-          margin-top: 50px;
+          overflow: hidden;
+          position: relative;
+          margin-top: 45px;
         `}
       >
-        {revisitAnalysis.length === 0 ? (
-          <NoRevisit />
-        ) : (
-          <>
-            <RevisitTitle active={true} />
-            <div css={CSSPhotoListContainer}>
-              {revisitAnalysis.map((thum) => (
-                <RevisitPhotoList key={thum.scrap_id} thumId={thum.scrap_id} thum={thum} title={thum.title} />
-              ))}
-            </div>
-          </>
-        )}
+        <div
+          css={css`
+            position: absolute;
+            overflow: auto;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+          `}
+        >
+          {revisitAnalysis.length === 0 ? (
+            <NoRevisit />
+          ) : (
+            <>
+              <div
+                css={css`
+                  margin: 10px 0;
+                `}
+              >
+                <RevisitTitle active={true} />
+              </div>
+              <div css={CSSPhotoListContainer}>
+                {revisitAnalysis.map((thum) => (
+                  <RevisitPhotoList key={thum.scrap_id} thumId={thum.scrap_id} thum={thum} title={thum.title} />
+                ))}
+              </div>
+            </>
+          )}
+        </div>
       </div>
     </>
   );

--- a/src/containers/analysis/RevisitAnalysis/RevisitAnalysisDetail.tsx
+++ b/src/containers/analysis/RevisitAnalysis/RevisitAnalysisDetail.tsx
@@ -1,15 +1,17 @@
 import { css } from '@emotion/react';
 
+import RevisitTitle from '@/components/analysis/Revisit/RevisitTitle';
+
 const RevisitAnalysisDetail = () => {
   return (
     <>
       <div
         css={css`
           height: 100%;
-          margin-top: 24px;
+          margin-top: 50px;
         `}
       >
-        재방문 콘텐츠 디테일 페이지
+        <RevisitTitle active={true} />
       </div>
     </>
   );

--- a/src/containers/analysis/RevisitAnalysis/RevisitAnalysisDetail.tsx
+++ b/src/containers/analysis/RevisitAnalysis/RevisitAnalysisDetail.tsx
@@ -1,8 +1,14 @@
 import { css } from '@emotion/react';
 
+import { useGetRevisitAnalysis } from '@/application/hooks/api/analysis';
+import NoRevisit from '@/components/analysis/Revisit/NoRevisit';
+import RevisitPhotoList from '@/components/analysis/Revisit/RevisitPhotoList';
 import RevisitTitle from '@/components/analysis/Revisit/RevisitTitle';
 
 const RevisitAnalysisDetail = () => {
+  const { revisitAnalysis } = useGetRevisitAnalysis();
+  console.log(revisitAnalysis);
+
   return (
     <>
       <div
@@ -11,10 +17,28 @@ const RevisitAnalysisDetail = () => {
           margin-top: 50px;
         `}
       >
-        <RevisitTitle active={true} />
+        {revisitAnalysis.length === 0 ? (
+          <NoRevisit />
+        ) : (
+          <>
+            <RevisitTitle active={true} />
+            <div css={CSSPhotoListContainer}>
+              {revisitAnalysis.map((thum) => (
+                <RevisitPhotoList key={thum.scrap_id} thumId={thum.scrap_id} thum={thum} title={thum.title} />
+              ))}
+            </div>
+          </>
+        )}
       </div>
     </>
   );
 };
+
+const CSSPhotoListContainer = css`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(60px, 1fr));
+  gap: 9px;
+  margin-top: 24px;
+`;
 
 export default RevisitAnalysisDetail;

--- a/src/infra/api/analysis.ts
+++ b/src/infra/api/analysis.ts
@@ -1,6 +1,7 @@
 import { instance } from '@/infra/api/instance';
 import type {
   GetAnalysisDetailResponse,
+  GetRevisitAnalysisResponse,
   GetTagAnalysisForYear,
   GetTagAnalysisForYearMonth,
 } from '@/infra/api/types/analysis';
@@ -16,6 +17,9 @@ class AnalysisApi {
   };
   getTagAnalysisForYearMonth = ({ year, month }: GetTagAnalysisForYearMonth) => {
     return this.api.get<GetAnalysisDetailResponse>(`/analysis?filter=month&year=${year}&month=${month}`);
+  };
+  getRevisitAnalysis = () => {
+    return this.api.get<GetRevisitAnalysisResponse>('/analysis/revisit?filter=all');
   };
 }
 

--- a/src/infra/api/types/analysis.ts
+++ b/src/infra/api/types/analysis.ts
@@ -7,3 +7,5 @@ export interface GetTagAnalysisForYear {
 export interface GetTagAnalysisForYearMonth extends GetTagAnalysisForYear {
   month: number;
 }
+
+export type GetRevisitAnalysisResponse = RevisitAnalysis[];

--- a/src/pages/scrap/[id].tsx
+++ b/src/pages/scrap/[id].tsx
@@ -33,7 +33,7 @@ const ShowScrap: NextPage = () => {
     scrapType === 'text'
       ? { text: scrap?.content, type: scrapType }
       : scrapType === 'link'
-      ? { src: scrap?.url_preview, type: scrapType, href: scrap?.content || '' }
+      ? { src: scrap?.preview_url, type: scrapType, href: scrap?.content || '' }
       : { src: scrap?.file_url, type: scrapType };
 
   return (

--- a/src/styles/font.ts
+++ b/src/styles/font.ts
@@ -51,6 +51,7 @@ export const font = {
   B_POINT_18: FONT({ size: 18, family: 'SCoreDream', weight: 'B' }),
   M_POINT_20: FONT({ size: 20, family: 'SCoreDream', weight: 'M' }),
   B_POINT_20: FONT({ size: 20, family: 'SCoreDream', weight: 'B' }),
+  B_POINT_22: FONT({ size: 22, family: 'SCoreDream', weight: 'B' }),
   B_POINT_24: FONT({ size: 24, family: 'SCoreDream', weight: 'B' }),
   B_POINT_28: FONT({ size: 28, family: 'SCoreDream', weight: 'B' }),
 };

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -77,3 +77,8 @@ interface Analysis {
   hashtags: HashTagAnalysis[];
   texts: TextAnalysis[];
 }
+
+interface RevisitAnalysis {
+  scrap_id: number;
+  title: string;
+}

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -57,7 +57,7 @@ interface Magazine {
 interface EditPage {
   scrap_id: number;
   text: string;
-  src: string | undefined | null;
+  src: string;
   placeholder?: string;
 }
 
@@ -83,6 +83,6 @@ interface RevisitAnalysis {
   scrap_id: number;
   scrap_type: string;
   title: string;
-  preview_url?: null;
+  preview_url: string;
   file_url: string;
 }

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -57,7 +57,7 @@ interface Magazine {
 interface EditPage {
   scrap_id: number;
   text: string;
-  src: string;
+  src: string | undefined | null;
   placeholder?: string;
 }
 

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -12,7 +12,7 @@ type ScrapType = 'image' | 'text' | 'link' | 'video' | 'pdf';
 interface Category {
   content: string;
   file_url: string;
-  url_preview: string;
+  preview_url: string;
   id: number;
   name: string;
   scrap_type: ScrapType;
@@ -28,7 +28,7 @@ interface Scrap {
   memo: string;
   scrap_type: ScrapType;
   title: string;
-  url_preview: string;
+  preview_url: string;
 }
 
 interface Page {
@@ -79,6 +79,10 @@ interface Analysis {
 }
 
 interface RevisitAnalysis {
+  content: string;
   scrap_id: number;
+  scrap_type: string;
   title: string;
+  preview_url?: null;
+  file_url: string;
 }


### PR DESCRIPTION
## 📮 관련 이슈
- Resolved: #이슈번호

## ⛳️ 작업 내용

- 메인 분석페이지 재방문 페이지 UI 스타일링
- 더보기 재방문 페이지 UI 스타일링
- 재방문 API 연결 (메인페이지에서는 미리보기용으로 데이터 2개만 표시되도록 함)
- 재방문 할 데이터가 없을 시 컴포넌트 예외 처리

## 🌱 PR 포인트
- 스크랩을 방문하면 해당 데이터 정보가 변경되어 재방문 페이지에서는 찾아볼 수 없음

## 📸 스크린샷
|스크린샷|
|:--:|
|![재방문콘텐츠](https://user-images.githubusercontent.com/81777778/216832195-f4c0cc1c-115e-4827-b099-8b0cf34d4a02.gif)|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->