### PR TITLE
Fix: QA 매거진 관련 요소 수정

### DIFF
--- a/src/application/store/magazine/state.ts
+++ b/src/application/store/magazine/state.ts
@@ -70,3 +70,8 @@ export const pageIdsArray = atom<Array<number>>({
   key: 'pageIdsArray',
   default: [],
 });
+
+export const magazineCoverId = atom({
+  key: 'magazineCoverId',
+  default: '',
+});

--- a/src/application/utils/mock.ts
+++ b/src/application/utils/mock.ts
@@ -20,6 +20,7 @@ export const MEMO = `사람에게는 저마다의 바다가  있고 사람에게
 export const PAGES = [0, 0, 0, 0].map(() => ({
   contents: MEMO,
   file_url: '/picture/mock.png',
+  preview_url: '/preview/mock.png',
   page_id: 0,
   text: MEMO,
   type: 'page' as const,

--- a/src/components/common/Modal/Input.tsx
+++ b/src/components/common/Modal/Input.tsx
@@ -11,9 +11,10 @@ interface Props {
   onSubmit?: (value: string, errorFn: Dispatch<SetStateAction<boolean>>) => void;
   title: string;
   errMsg?: string;
+  defaultValue?: string;
 }
 
-const InputModal = ({ onSubmit, title, errMsg }: Props) => {
+const InputModal = ({ onSubmit, title, errMsg, defaultValue }: Props) => {
   const [category, setCategory] = useInput({ maxLength: 15 });
   const [isError, setIsError] = useState(false);
   const { close } = useToast();
@@ -36,9 +37,9 @@ const InputModal = ({ onSubmit, title, errMsg }: Props) => {
         <InputLabel htmlFor={'category'}>{title}</InputLabel>
         <InputBase
           rightPlaceholder={`${category.length}/15`}
-          value={category}
           onChange={(e) => setCategory(e.target.value)}
           id={'category'}
+          defaultValue={defaultValue}
         />
         {isError ? (
           <span

--- a/src/components/common/Popup/MagazineWarningSentence.tsx
+++ b/src/components/common/Popup/MagazineWarningSentence.tsx
@@ -1,0 +1,17 @@
+import { css } from '@emotion/react';
+import React from 'react';
+
+export const MagazineWarningPopup = (
+  <span>
+    매거진 표지를{' '}
+    <span
+      css={(theme) =>
+        css`
+          color: ${theme.color.gray06};
+        `
+      }
+    >
+      설정해주세요!
+    </span>
+  </span>
+);

--- a/src/components/common/Toast/ui/Input.tsx
+++ b/src/components/common/Toast/ui/Input.tsx
@@ -13,8 +13,9 @@ interface InputProps {
   type: 'input' | 'textarea';
   label: string;
   submit: string;
+  defaultValue?: string;
 }
-const ToastInput = ({ onSubmit, onBack, title, type, label, submit }: InputProps) => {
+const ToastInput = ({ onSubmit, onBack, title, type, label, submit, defaultValue }: InputProps) => {
   const ref = useRef<HTMLInputElement | HTMLTextAreaElement>();
 
   return (
@@ -42,7 +43,7 @@ const ToastInput = ({ onSubmit, onBack, title, type, label, submit }: InputProps
           `
         }
       >
-        <Image src={'/icon/backArrow.svg'} width={10} height={17} onClick={onBack} />
+        <Image src={'/icon/backArrow.svg'} width={10} height={17} onClick={onBack} alt="뒤로가기" />
         {title}
       </span>
 
@@ -77,6 +78,7 @@ const ToastInput = ({ onSubmit, onBack, title, type, label, submit }: InputProps
                   border-color: ${theme.color.black02};
                 }
               `}
+              defaultValue={defaultValue}
             />
           </>
         )}

--- a/src/components/magazine/MagazineList/TabMagazine.tsx
+++ b/src/components/magazine/MagazineList/TabMagazine.tsx
@@ -5,7 +5,7 @@ import { useSetRecoilState } from 'recoil';
 
 import type { UseScrollDetectOption } from '@/application/hooks/utils/useScrollDetect';
 import useScrollDetect from '@/application/hooks/utils/useScrollDetect';
-import { magazineIdsArray } from '@/application/store/magazine/state';
+import { magazineCoverId, magazineIdsArray } from '@/application/store/magazine/state';
 import Photo from '@/components/common/Photo';
 import PhotoSelect from '@/components/common/Photo/PhotoSelect';
 import NoMagazine from '@/components/magazine/NoMagazine';
@@ -20,6 +20,8 @@ interface TabMagazineProps {
 const TabMagazine = ({ magazines, selectItem, selectDeleteBtn, onScrollDown }: TabMagazineProps) => {
   const ref = useScrollDetect<HTMLDivElement>({ onScroll: onScrollDown });
   const multiSelectOn = selectDeleteBtn;
+
+  const magazineCover = useSetRecoilState(magazineCoverId);
 
   // 썸네일 클릭 시 해당 id 추가, 선택 취소 시 id 확인 후 제거
   const setMagazineItems = useSetRecoilState(magazineIdsArray);
@@ -84,14 +86,16 @@ const TabMagazine = ({ magazines, selectItem, selectDeleteBtn, onScrollDown }: T
                   />
                 </div>
               ) : (
-                <Link href={`/magazine/${magazine.magazine_id}`}>
-                  <Photo
-                    blur={<PhotoSelect enabled={selectItem} />}
-                    src={magazine.cover_url}
-                    width={'196px'}
-                    height={'255px'}
-                  />
-                </Link>
+                <div onClick={() => magazineCover(magazine.cover_url)}>
+                  <Link href={`/magazine/${magazine.magazine_id}`}>
+                    <Photo
+                      blur={<PhotoSelect enabled={selectItem} />}
+                      src={magazine.cover_url}
+                      width={'196px'}
+                      height={'255px'}
+                    />
+                  </Link>
+                </div>
               )}
               <span
                 css={(theme) =>

--- a/src/components/magazine/PageList/index.tsx
+++ b/src/components/magazine/PageList/index.tsx
@@ -1,4 +1,5 @@
 import { css } from '@emotion/react';
+import { useRouter } from 'next/router';
 import { useCallback, useRef } from 'react';
 import { useSetRecoilState } from 'recoil';
 
@@ -11,6 +12,8 @@ interface Props {
 }
 
 const PageList = ({ pages, selectItem }: Props) => {
+  const router = useRouter();
+
   // 썸네일 클릭 시 해당 id 추가, 선택 취소 시 id 확인 후 제거
   const setPageItems = useSetRecoilState(pageIdsArray);
   const pickSet = useRef(new Set<number>());
@@ -22,6 +25,15 @@ const PageList = ({ pages, selectItem }: Props) => {
     },
     [pickSet, setPageItems],
   );
+
+  const handleMultiClickItem = (id: number) => {
+    selectPageItems(id);
+  };
+
+  const handleEditItem = (id: number) => {
+    console.log('click!', id);
+    // router.push('/magazine/upload/page');
+  };
 
   return (
     <div
@@ -35,7 +47,13 @@ const PageList = ({ pages, selectItem }: Props) => {
       {pages.map((page, idx) => (
         <div
           key={idx}
-          onClick={() => selectItem && idx !== 0 && idx !== pages.length - 1 && selectPageItems(page.scrap_id!)}
+          onClick={() => {
+            idx !== 0 && idx !== pages.length
+              ? selectItem
+                ? handleMultiClickItem(page.scrap_id!)
+                : handleEditItem(page.scrap_id!)
+              : '';
+          }}
         >
           {idx === 0 || idx === pages.length - 1 ? (
             <PageListItem item={page} ratio={'100/134'} />

--- a/src/containers/magazine/MagazineCreateContainer.tsx
+++ b/src/containers/magazine/MagazineCreateContainer.tsx
@@ -26,6 +26,7 @@ const MagazineCreateContainer = ({ thumbnails, selectItem }: Props) => {
     modal(
       <InputModal
         title={'제목 수정'}
+        defaultValue={magazineInfo.title}
         errMsg={ERR_MESSAGE.DUPLICATED_TITLE}
         onSubmit={(value, errorFn) => {
           mutation.mutate(value, {

--- a/src/containers/magazine/PageEditContainer.tsx
+++ b/src/containers/magazine/PageEditContainer.tsx
@@ -132,7 +132,7 @@ const CSSCarouselContainer = css`
   bottom: 0;
   left: 0;
   display: flex;
-  overflow-x: auto;
+  overflow-x: hidden;
   counter-reset: item;
   scroll-behavior: smooth;
   scroll-snap-type: x mandatory;

--- a/src/containers/magazine/PageEditContainer.tsx
+++ b/src/containers/magazine/PageEditContainer.tsx
@@ -100,6 +100,7 @@ const PageEditContainer = ({ pages, startPage }: Props) => {
               right: 0;
               gap: 12px;
               display: flex;
+              background-color: white;
             `}
           >
             <Link href={{ hash: `${getPrevPage(currentPage) + startPage}` }}>
@@ -108,6 +109,7 @@ const PageEditContainer = ({ pages, startPage }: Props) => {
                 src={'/icon/magazine/prevPage.svg'}
                 width={48}
                 height={48}
+                alt="이전 버튼"
               />
             </Link>
             <Link href={{ hash: `${getNextPage(currentPage) + startPage}` }}>
@@ -116,6 +118,7 @@ const PageEditContainer = ({ pages, startPage }: Props) => {
                 src={'/icon/magazine/nextPage.svg'}
                 width={48}
                 height={48}
+                alt="다음 버튼"
               />
             </Link>
           </div>

--- a/src/containers/magazine/PageEditContainer.tsx
+++ b/src/containers/magazine/PageEditContainer.tsx
@@ -44,6 +44,7 @@ const PageEditContainer = ({ pages, startPage }: Props) => {
     type: 'textarea' as const,
     title: '텍스트 입력하기',
   };
+
   return (
     <>
       <span
@@ -82,7 +83,7 @@ const PageEditContainer = ({ pages, startPage }: Props) => {
                   css={CSSPageContent}
                   onClick={() =>
                     show({
-                      content: <ToastInput {...toastProps} />,
+                      content: <ToastInput {...toastProps} defaultValue={editPageInfo[idx].text} onBack={close} />,
                     })
                   }
                 >

--- a/src/containers/magazine/PageViewContainer.tsx
+++ b/src/containers/magazine/PageViewContainer.tsx
@@ -35,7 +35,7 @@ const PageViewContainer = ({ pages = PAGES }: Props) => {
           {pages.map((page, idx) => (
             <li key={page.page_id} id={`${idx + 1}`} css={CSSCarouselItem}>
               <Photo
-                src={page.file_url || getValidURL(page.contents).toString()}
+                src={page.file_url === null ? page.preview_url : page.file_url || getValidURL(page.contents).toString()}
                 text={page.contents}
                 height={'45vh'}
               />

--- a/src/containers/magazine/PageViewContainer.tsx
+++ b/src/containers/magazine/PageViewContainer.tsx
@@ -15,6 +15,10 @@ interface Props {
 }
 
 const PageViewContainer = ({ pages = PAGES }: Props) => {
+  const handleClickLink = (link: string) => {
+    window.open(link, '_blank', 'noopener, noreferrer');
+  };
+
   return (
     <>
       <article
@@ -38,6 +42,10 @@ const PageViewContainer = ({ pages = PAGES }: Props) => {
                 src={page.file_url === null ? page.preview_url : page.file_url || getValidURL(page.contents).toString()}
                 text={page.contents}
                 height={'45vh'}
+                custom={css`
+                  z-index: 3;
+                `}
+                onClick={() => page.contents && handleClickLink(page.contents)}
               />
               <p css={CSSPageContent}>{page.text}</p>
               <div css={CSSSnapper} />

--- a/src/containers/magazine/TabMagazineViewContainer.tsx
+++ b/src/containers/magazine/TabMagazineViewContainer.tsx
@@ -32,7 +32,7 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
   const magazineDeleteList = useMagazineDeleteList();
   const resetMagazineList = useResetMagazineDeleteList();
   const ref = useRef<SelectContext>('myMagazine');
-  const { show } = useToast();
+  const { show, close } = useToast();
   const popup = usePopup();
 
   const mutation = useDeleteMagazines();
@@ -47,7 +47,8 @@ const MyMagazineWithTab = ({ onScrollDown }: MagazineTabProps) => {
     ref.current = key;
   };
 
-  const showDeleteMagazineToast = () => show({ content: <DeleteScrapToast onDelete={handleDeleteMagazine} /> });
+  const showDeleteMagazineToast = () =>
+    show({ content: <DeleteScrapToast onBack={close} onDelete={handleDeleteMagazine} /> });
 
   const handleMultiSelect = () => {
     isSelectDeleteBtn(!selectDeleteBtn);

--- a/src/pages/magazine/edit/[id].tsx
+++ b/src/pages/magazine/edit/[id].tsx
@@ -34,7 +34,6 @@ const EditMagazine: NextPage = () => {
   const mutation = useUpdateMagazine();
   const resetMagazineInfo = useResetMagazineInfo();
   const resetEditPage = useEditPageReset();
-  // const getMagazineCover = useRecoilValue(magazineCoverId);
 
   const pageDeleteList = usePageDeleteList();
 
@@ -48,7 +47,8 @@ const EditMagazine: NextPage = () => {
     popup(DeletePopup, 'success');
   };
 
-  const showDeletePagesToast = () => show({ content: <DeleteScrapToast onDelete={handleDeletePages} /> });
+  const showDeletePagesToast = () =>
+    show({ content: <DeleteScrapToast onBack={close} onDelete={handleDeletePages} /> });
 
   const handleMultiSelect = () => {
     setSelected(!selected);

--- a/src/pages/magazine/edit/[id].tsx
+++ b/src/pages/magazine/edit/[id].tsx
@@ -3,6 +3,7 @@ import type { NextPage } from 'next';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
 import React, { useMemo, useState } from 'react';
+import { useRecoilState } from 'recoil';
 
 import { useDeletePages, useUpdateMagazine } from '@/application/hooks/api/magazine';
 import usePopup from '@/application/hooks/common/usePopup';
@@ -14,6 +15,7 @@ import {
   useResetMagazineInfo,
   useSetMagazineInfo,
 } from '@/application/store/magazine/hook';
+import { magazineCoverId } from '@/application/store/magazine/state';
 import SelectCategoryWithContent from '@/components/category/Select/SelectCategoryWithContent';
 import { ActiveButton } from '@/components/common/Button';
 import { DeletePopup } from '@/components/common/Popup/Sentence';
@@ -26,12 +28,13 @@ const EditMagazine: NextPage = () => {
   const id = router.query.id ? Number(router.query.id) : 0;
   const { show, close } = useToast();
   const setMagazineInfo = useSetMagazineInfo();
-  const [coverUrl, setCoverUrl] = useState('');
+  const [coverUrl, setCoverUrl] = useRecoilState(magazineCoverId);
   const magazineInfo = useMagazineInfo();
   const [_, setEditPage] = useEditPageSet();
   const mutation = useUpdateMagazine();
   const resetMagazineInfo = useResetMagazineInfo();
   const resetEditPage = useEditPageReset();
+  // const getMagazineCover = useRecoilValue(magazineCoverId);
 
   const pageDeleteList = usePageDeleteList();
 
@@ -133,7 +136,7 @@ const EditMagazine: NextPage = () => {
     });
 
     return ret;
-  }, [close, coverUrl, magazineInfo.page_list, router, selected, setEditPage, setMagazineInfo, show]);
+  }, [close, coverUrl, magazineInfo.page_list, router, selected, setCoverUrl, setEditPage, setMagazineInfo, show]);
 
   return (
     <>

--- a/src/pages/magazine/upload/index.tsx
+++ b/src/pages/magazine/upload/index.tsx
@@ -54,7 +54,7 @@ const UploadMagazine: NextPage = () => {
       {
         cover_url: magazineInfo.cover_scrap_src,
         placeholder: magazineInfo.cover_scrap_placeholder,
-        title: '1 페이지',
+        title: '표지 설정',
         magazine_id: 0,
         onClick: () =>
           show({
@@ -75,7 +75,7 @@ const UploadMagazine: NextPage = () => {
       ...magazineInfo.page_list.map((page, idx) => ({
         cover_url: page.src,
         placeholder: page.placeholder,
-        title: `${idx + 2} 페이지`,
+        title: `${idx + 1} 페이지`,
         magazine_id: idx,
       })),
     ];

--- a/src/pages/magazine/upload/index.tsx
+++ b/src/pages/magazine/upload/index.tsx
@@ -16,6 +16,7 @@ import {
 } from '@/application/store/magazine/hook';
 import SelectCategoryWithContent from '@/components/category/Select/SelectCategoryWithContent';
 import { ActiveButton } from '@/components/common/Button';
+import { MagazineWarningPopup } from '@/components/common/Popup/MagazineWarningSentence';
 import { DeletePopup } from '@/components/common/Popup/Sentence';
 import DeleteNavigation from '@/components/scrap/DeleteNavigation';
 import { DeleteScrapToast } from '@/components/scrap/Toast';
@@ -72,11 +73,17 @@ const UploadMagazine: NextPage = () => {
     });
   };
 
+  console.log('커버설정', magazineInfo);
+
   const handleComplete = () => {
-    mutation.mutate(magazineInfo, {
-      onSuccess: handleBack,
-    });
-    console.debug('complete :::', magazineInfo);
+    if (magazineInfo.cover_scrap_id === 0) {
+      popup(MagazineWarningPopup, 'warn');
+    } else {
+      mutation.mutate(magazineInfo, {
+        onSuccess: handleBack,
+      });
+      console.debug('complete :::', magazineInfo);
+    }
   };
 
   const pages = useMemo(() => {

--- a/src/pages/magazine/upload/index.tsx
+++ b/src/pages/magazine/upload/index.tsx
@@ -5,11 +5,18 @@ import { useRouter } from 'next/router';
 import React, { useMemo, useState } from 'react';
 
 import { useSaveMagazine } from '@/application/hooks/api/magazine';
+import usePopup from '@/application/hooks/common/usePopup';
 import useToast from '@/application/hooks/common/useToast';
 import { useEditPageReset, useEditPageSet } from '@/application/store/edit/hook';
-import { useMagazineInfo, useResetMagazineInfo, useSetMagazineInfo } from '@/application/store/magazine/hook';
+import {
+  useMagazineInfo,
+  usePageDeleteList,
+  useResetMagazineInfo,
+  useSetMagazineInfo,
+} from '@/application/store/magazine/hook';
 import SelectCategoryWithContent from '@/components/category/Select/SelectCategoryWithContent';
 import { ActiveButton } from '@/components/common/Button';
+import { DeletePopup } from '@/components/common/Popup/Sentence';
 import DeleteNavigation from '@/components/scrap/DeleteNavigation';
 import { DeleteScrapToast } from '@/components/scrap/Toast';
 import MagazineCreateContainer from '@/containers/magazine/MagazineCreateContainer';
@@ -28,10 +35,17 @@ import MagazineCreateContainer from '@/containers/magazine/MagazineCreateContain
 const UploadMagazine: NextPage = () => {
   const router = useRouter();
   const { show, close } = useToast();
+  const popup = usePopup();
   const [selected, setSelected] = useState(false);
+  const pageDeleteList = usePageDeleteList();
 
   const handleClickReset = () => {
     setSelected(false);
+  };
+
+  const handleDeletePages = () => {
+    setSelected(false);
+    popup(DeletePopup, 'success');
   };
 
   const handleMultiSelect = () => {
@@ -40,7 +54,7 @@ const UploadMagazine: NextPage = () => {
 
   const showDeletePagesToast = () =>
     show({
-      content: <DeleteScrapToast onBack={close} />,
+      content: <DeleteScrapToast onBack={close} onDelete={handleDeletePages} />,
     });
 
   const magazineInfo = useMagazineInfo();
@@ -69,6 +83,7 @@ const UploadMagazine: NextPage = () => {
     const ret: (MagazineThumbnail & { onClick?: () => void })[] = [
       {
         cover_url: magazineInfo.cover_scrap_src,
+        scrap_id: magazineInfo.cover_scrap_id,
         placeholder: magazineInfo.cover_scrap_placeholder,
         title: '표지 설정',
         magazine_id: 0,
@@ -90,6 +105,7 @@ const UploadMagazine: NextPage = () => {
       },
       ...magazineInfo.page_list.map((page, idx) => ({
         cover_url: page.src,
+        scrap_id: page.scrap_id,
         placeholder: page.placeholder,
         title: `${idx + 1} 페이지`,
         magazine_id: idx,
@@ -140,7 +156,7 @@ const UploadMagazine: NextPage = () => {
             left: 0;
           `}
         >
-          <Image src={'/icon/backArrow.svg'} layout={'fill'} objectFit={'cover'} />
+          <Image src={'/icon/backArrow.svg'} layout={'fill'} objectFit={'cover'} alt="뒤로가기" />
         </span>
         <span
           onClick={handleMultiSelect}
@@ -157,13 +173,13 @@ const UploadMagazine: NextPage = () => {
           {selected ? (
             <p onClick={handleClickReset}>취소</p>
           ) : (
-            <Image src={'/icon/multiSelect.svg'} width={18} height={18} />
+            <Image src={'/icon/multiSelect.svg'} width={18} height={18} alt="삭제" />
           )}
         </span>
       </div>
       <MagazineCreateContainer thumbnails={pages} selectItem={selected} />
       {selected ? (
-        <DeleteNavigation onClick={() => showDeletePagesToast} />
+        <DeleteNavigation onClick={showDeletePagesToast} />
       ) : (
         <ActiveButton
           active={!!magazineInfo.cover_scrap_id}

--- a/src/pages/magazine/upload/index.tsx
+++ b/src/pages/magazine/upload/index.tsx
@@ -73,8 +73,6 @@ const UploadMagazine: NextPage = () => {
     });
   };
 
-  console.log('커버설정', magazineInfo);
-
   const handleComplete = () => {
     if (magazineInfo.cover_scrap_id === 0) {
       popup(MagazineWarningPopup, 'warn');

--- a/src/pages/magazine/upload/index.tsx
+++ b/src/pages/magazine/upload/index.tsx
@@ -2,7 +2,7 @@ import { css } from '@emotion/react';
 import type { NextPage } from 'next';
 import Image from 'next/image';
 import { useRouter } from 'next/router';
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { useSaveMagazine } from '@/application/hooks/api/magazine';
 import useToast from '@/application/hooks/common/useToast';
@@ -10,6 +10,8 @@ import { useEditPageReset, useEditPageSet } from '@/application/store/edit/hook'
 import { useMagazineInfo, useResetMagazineInfo, useSetMagazineInfo } from '@/application/store/magazine/hook';
 import SelectCategoryWithContent from '@/components/category/Select/SelectCategoryWithContent';
 import { ActiveButton } from '@/components/common/Button';
+import DeleteNavigation from '@/components/scrap/DeleteNavigation';
+import { DeleteScrapToast } from '@/components/scrap/Toast';
 import MagazineCreateContainer from '@/containers/magazine/MagazineCreateContainer';
 
 /**
@@ -26,6 +28,20 @@ import MagazineCreateContainer from '@/containers/magazine/MagazineCreateContain
 const UploadMagazine: NextPage = () => {
   const router = useRouter();
   const { show, close } = useToast();
+  const [selected, setSelected] = useState(false);
+
+  const handleClickReset = () => {
+    setSelected(false);
+  };
+
+  const handleMultiSelect = () => {
+    setSelected(!selected);
+  };
+
+  const showDeletePagesToast = () =>
+    show({
+      content: <DeleteScrapToast onBack={close} />,
+    });
 
   const magazineInfo = useMagazineInfo();
   const setMagazineInfo = useSetMagazineInfo();
@@ -127,6 +143,7 @@ const UploadMagazine: NextPage = () => {
           <Image src={'/icon/backArrow.svg'} layout={'fill'} objectFit={'cover'} />
         </span>
         <span
+          onClick={handleMultiSelect}
           css={(theme) =>
             css`
               ${theme.font.R_BODY_15};
@@ -137,19 +154,27 @@ const UploadMagazine: NextPage = () => {
             `
           }
         >
-          <Image src={'/icon/multiSelect.svg'} width={18} height={18} />
+          {selected ? (
+            <p onClick={handleClickReset}>취소</p>
+          ) : (
+            <Image src={'/icon/multiSelect.svg'} width={18} height={18} />
+          )}
         </span>
       </div>
-      <MagazineCreateContainer thumbnails={pages} />
-      <ActiveButton
-        active={!!magazineInfo.cover_scrap_id}
-        onClick={handleComplete}
-        custom={css`
-          margin-top: auto;
-        `}
-      >
-        완료
-      </ActiveButton>
+      <MagazineCreateContainer thumbnails={pages} selectItem={selected} />
+      {selected ? (
+        <DeleteNavigation onClick={() => showDeletePagesToast} />
+      ) : (
+        <ActiveButton
+          active={!!magazineInfo.cover_scrap_id}
+          onClick={handleComplete}
+          custom={css`
+            margin-top: auto;
+          `}
+        >
+          완료
+        </ActiveButton>
+      )}
     </>
   );
 };

--- a/src/pages/magazine/upload/page.tsx
+++ b/src/pages/magazine/upload/page.tsx
@@ -30,7 +30,7 @@ const UploadPage: NextPage = () => {
   const resetEditPages = useEditPageReset();
   const editContainerProps = {
     pages: editPages,
-    startPage: magazineInfo.start_number,
+    startPage: magazineInfo.start_number - 1,
   };
   return (
     <>

--- a/src/pages/scrap/index.tsx
+++ b/src/pages/scrap/index.tsx
@@ -50,7 +50,7 @@ const Scrap: NextPage = () => {
 
   const [categoryInfo, setCategoryInfo] = useState<{ id: number; name: string }>({ id: 0, name: '' });
   const ref = useRef<SelectContextKey>('category');
-  const { show } = useToast();
+  const { show, close } = useToast();
   const popup = usePopup();
 
   const handleDeleteScrap = () => {
@@ -64,7 +64,8 @@ const Scrap: NextPage = () => {
     popup(DeletePopup, 'success');
   };
 
-  const showDeleteScrapToast = () => show({ content: <DeleteScrapToast onDelete={handleDeleteScrap} /> });
+  const showDeleteScrapToast = () =>
+    show({ content: <DeleteScrapToast onBack={close} onDelete={handleDeleteScrap} /> });
 
   const handleTabClick = (key: SelectContextKey) => {
     ref.current = key;

--- a/src/types/index.d.ts
+++ b/src/types/index.d.ts
@@ -35,6 +35,7 @@ interface Page {
   contents: string;
   file_url: string;
   page_id: number;
+  preview_url: string;
   text: string;
 }
 


### PR DESCRIPTION
## 📮 관련 이슈
- Resolved: #이슈번호

## ⛳️ 작업 내용
수정되는 대로 아래에 더 추가할 예정입니다.

- [x] 매거진 수정 시 표지 사라지는 현상
- [x] 매거진에 스크랩 여러 장 추가 시 손으로도 이동 가능한 현상
- [x] 삭제토스트 뒤로가기 버튼에 close 함수 활성화
- [x] 매거진 페이지 추가 시 입력했던 텍스트를 토스트 Input 에서도 보일 수 있도록 수정
- [x] 매거진 제목 변경 시 입력했던 제목을 Input에서도 보일 수 있도록 수정
- [x] 매거진 내 삽입된 링크 콘텐츠는 클릭했을 때 해당 링크로 이동 가능하도록 수정
- [x] 매거진 표지 설정하지 않고 완료버튼 누를 시 안내 팝업 띄우기
- [ ] 매거진 제작 페이지에도 다중 선택 버튼 작동할 수 있도록 수정(원하는 스크랩을 제작 중에도 삭제할 수 있도록)
- [ ] 매거진 생성 및 수정 페이지에서도 원하는 스크랩을 선택하여 입력했던 것들을 바꿀 수 있도록 수정

## 🌱 PR 포인트

## 📸 스크린샷
|스크린샷|
|:--:|
|파일첨부바람|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->