### PR TITLE
Design: 탐색페이지 검색 시 UI 스타일링

### DIFF
--- a/src/application/utils/mock.ts
+++ b/src/application/utils/mock.ts
@@ -47,3 +47,13 @@ export const SCRAPS = [0, 0, 0, 0, 0, 0].map(() => ({
   url_preview: '',
 }));
 export const EDIT_PAGE = [0, 0, 0, 0, 0].map(() => ({ scrap_id: 0, text: '', src: '/picture/mock.png' }));
+
+export const SEARCH_MAGAZINE = [
+  { user: '김수정', title: '최애 마블 장면' },
+  { user: '김소희', title: '사랑에 대해 고민하게 만드는 영화영화영화' },
+  { user: '유정민', title: '심오한 주제 어쩌구저쩌구' },
+  { user: '문민혁', title: 'Musical movie' },
+  { user: '윤태민', title: '어벤져스에 대해 알아보자' },
+  { user: '뉴진스', title: '뉴진스의 하입보이요 HYPE BOY' },
+  { user: '토끼', title: '산토끼 토끼야' },
+];

--- a/src/components/common/Photo/index.tsx
+++ b/src/components/common/Photo/index.tsx
@@ -4,7 +4,7 @@ import Image from 'next/image';
 import type { ReactElement } from 'react';
 
 interface PhotoProps {
-  src: string | null | undefined;
+  src?: string | null | undefined;
   width?: string;
   height?: string;
   blur?: ReactElement;

--- a/src/containers/search/SearchListContainer.tsx
+++ b/src/containers/search/SearchListContainer.tsx
@@ -1,0 +1,19 @@
+import SearchPhotoListContainer from './SearchPhotoListContainer';
+
+interface SearchListContainerProps {
+  params?: string;
+}
+
+const SearchListContainer = ({ params }: SearchListContainerProps) => {
+  // TODO const { magazines, fetchNextPage } =
+  // TODO API 완성되면 magazines.length에 따라 return하기
+
+  return (
+    <>
+      <span style={{ height: 26 }} />
+      <SearchPhotoListContainer />
+    </>
+  );
+};
+
+export default SearchListContainer;

--- a/src/containers/search/SearchPhotoListContainer.tsx
+++ b/src/containers/search/SearchPhotoListContainer.tsx
@@ -1,0 +1,86 @@
+import { css } from '@emotion/react';
+
+// import { getSrcByType } from '@/application/utils/helper';
+import { SEARCH_MAGAZINE } from '@/application/utils/mock';
+import Photo from '@/components/common/Photo';
+import RoundPhoto from '@/components/common/Photo/RoundPhoto';
+
+const SearchPhotoListContainer = () => {
+  // TODO API 연결 후 작업할 것들
+  // const router = useRouter();
+  // const ref = useIntersectionObserver({ callback: onEndReached });
+
+  return (
+    <div
+      css={css`
+        position: relative;
+        height: 100%;
+        overflow-y: hidden;
+      `}
+    >
+      <div
+        css={css`
+          position: absolute;
+          overflow: auto;
+          top: 0;
+          left: 0;
+          right: 0;
+          bottom: 0;
+          padding-bottom: 26px;
+        `}
+      >
+        <div css={CSSPhotoListContainer}>
+          {SEARCH_MAGAZINE.map((magazine) => (
+            <div key={magazine.user}>
+              <Photo
+                custom={css`
+                  width: 100%;
+                  height: 202px;
+                `}
+              />
+              <p
+                css={(theme) => css`
+                  width: 100%;
+                  padding: 8px 8px 8px 0;
+                  overflow: hidden;
+                  text-overflow: ellipsis;
+                  white-space: nowrap;
+                  ${theme.font.M_BODY_12};
+                  color: ${theme.color.gray03};
+                `}
+              >
+                {magazine.title}
+              </p>
+              <div
+                css={css`
+                  display: flex;
+                  margin-bottom: 8px;
+                `}
+              >
+                <RoundPhoto width={'13px'} height={'13px'} src={''} />
+                <p
+                  css={(theme) => css`
+                    margin-left: 4px;
+                    ${theme.font.R_BODY_11}
+                    color: ${theme.color.gray06};
+                  `}
+                >
+                  {magazine.user}
+                </p>
+              </div>
+            </div>
+          ))}
+        </div>
+        {/* <span ref={ref} /> */}
+      </div>
+    </div>
+  );
+};
+
+const CSSPhotoListContainer = css`
+  display: grid;
+  grid-template-columns: repeat(2, minmax(60px, 1fr));
+  gap: 9px;
+`;
+
+export default SearchPhotoListContainer;

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -7,7 +7,7 @@ import Search from '@/components/common/Search';
 import { ThreeDotsSpinner } from '@/components/common/Spinner';
 import Tab from '@/components/common/Tab';
 import withNavigation from '@/containers/HOC/withNavigation';
-import SearchListContainer from '@/containers/scrap/SearchListContainer';
+import SearchListContainer from '@/containers/search/SearchListContainer';
 import SSRSafeSuspense from '@/containers/Suspense';
 
 const Browse: NextPage = () => {

--- a/src/pages/search/index.tsx
+++ b/src/pages/search/index.tsx
@@ -1,25 +1,53 @@
 import { css } from '@emotion/react';
 import type { NextPage } from 'next';
-import Image from 'next/image';
+import { useRouter } from 'next/router';
+import { useState } from 'react';
 
+import Search from '@/components/common/Search';
+import { ThreeDotsSpinner } from '@/components/common/Spinner';
+import Tab from '@/components/common/Tab';
 import withNavigation from '@/containers/HOC/withNavigation';
+import SearchListContainer from '@/containers/scrap/SearchListContainer';
+import SSRSafeSuspense from '@/containers/Suspense';
 
 const Browse: NextPage = () => {
+  const router = useRouter();
+  const [searchString, setSearchString] = useState<string | undefined>('');
+
+  const handleBack = () => {
+    router.push('/search');
+  };
+
+  const handleSearch = (search?: string) => {
+    setSearchString(search);
+  };
+
   return (
-    <div
-      css={(theme) => css`
-        display: flex;
-        margin: auto;
-        flex-direction: column;
-        ${theme.font.M_POINT_14};
-        color: ${theme.color.gray06};
-        text-align: center;
-        gap: 24px;
-      `}
-    >
-      <Image src={'/picture/warn.svg'} width={73} height={99} />
-      <p>서비스 준비중 입니다</p>
-    </div>
+    <>
+      <div
+        css={css`
+          display: flex;
+          justify-content: flex-end;
+          align-items: center;
+          margin-bottom: 10px;
+          width: 100%;
+          height: 28px;
+        `}
+      >
+        <Search onSubmit={handleSearch} onClosed={() => setSearchString('')} onClosedRoute={handleBack} />
+      </div>
+      {searchString ? (
+        <SSRSafeSuspense fallback={<ThreeDotsSpinner />}>
+          <SearchListContainer params={searchString} />
+        </SSRSafeSuspense>
+      ) : (
+        <Tab>
+          <Tab.Group>
+            <Tab.Label>매거진</Tab.Label>
+          </Tab.Group>
+        </Tab>
+      )}
+    </>
   );
 };
 


### PR DESCRIPTION
## 📮 관련 이슈
- Resolved: #이슈번호

## ⛳️ 작업 내용

탐색페이지에서 검색 후 나오는 매거진 목록의 UI를 완성했습니다.
API 연결이 되지 않아 우선 mock.ts 파일에 목업데이터를 추가하여 구현했습니다.

## 🌱 PR 포인트

## 📸 스크린샷
스크린샷 크기가 엄청 커졌네요 ;;
|스크린샷|
|:--:|
|![영상](https://user-images.githubusercontent.com/81777778/222736439-ce889b1b-34d3-476b-9b5f-2c866f52f59c.gif)|

## 📎 레퍼런스

<!-- 참고한 레퍼런스가 있다면 기록해주세요 -->